### PR TITLE
chore: pin Rust 1.93.0 toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable]
+        rust: [1.93.0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -73,6 +73,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.93.0
           components: rustfmt
 
       - name: Check formatting
@@ -88,6 +89,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.93.0
           components: clippy
 
       - name: Cache cargo registry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,11 @@
 **Version:** 1.0
 **Last Updated:** 2025-01-24
 
+Notes for this repo:
+
+- For Rust development tasks, use the local skill at `.claude/skills/rust-development/SKILL.md`.
+- Agents defined in `.claude/agents/*` can be used inline as guidance or reference because Codex does not support sub-agents.
+
 ---
 
 ## Project Overview

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "terminalg"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.93"
 authors = ["Your Name"]
 description = "GPU-accelerated terminal UI with integrated artifact viewing and test execution"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Built with modern Rust tooling:
 
 ## Requirements
 
-- **Rust** 1.70+ - Install from https://rustup.rs/
+- **Rust** 1.93.0 - Install from https://rustup.rs/
 - **Build tools:**
   - macOS: Xcode Command Line Tools
   - Linux: GCC/Clang + pkg-config

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,7 +74,7 @@ TerminalG is a GPU-accelerated terminal application built on GPUI, combining ter
 - See `docs/architecture/gpui-integration.md` for details
 
 **Rust Version:**
-- Minimum: 1.70+
+- Minimum: 1.93.0
 - Target: Latest stable
 
 ---

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -5,7 +5,7 @@ Get TerminalG building and running in 5 minutes.
 ## Prerequisites
 
 ### System Requirements
-- **Rust 1.70+** - https://rustup.rs/
+- **Rust 1.93.0** - https://rustup.rs/
 - **macOS 10.15+**, **Linux** (glibc 2.31+), or **Windows 10+**
 - **Git**
 
@@ -41,7 +41,7 @@ cd terminalg
 
 ### 2. Verify Rust Setup
 ```bash
-rustc --version  # Should be 1.70+
+rustc --version  # Should be 1.93.0
 cargo --version
 ```
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -178,7 +178,7 @@ Existing tools force workflows into constrained patterns:
 ### 6.1 Technology Stack
 
 **Required:**
-- Rust (1.70+)
+- Rust (1.93.0)
 - GPUI (Zed's UI framework, git dependency)
 - alacritty_terminal (terminal emulation)
 - smol (async runtime)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.93.0"
+components = ["clippy", "rustfmt"]
+profile = "default"


### PR DESCRIPTION
- Pin Rust toolchain to 1.93.0\n- Update CI and docs to reflect 1.93.0\n- Set Cargo rust-version to 1.93.0