### PR TITLE
ci: add concurrency groups to prevent duplicate workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,11 @@ on:
       - develop
   push:
     branches:
-      - main
-      - develop
+      - main  # Only direct pushes to main, PRs handle develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -32,7 +32,7 @@ Existing tools force workflows into constrained patterns:
 - **Hide/show any pane** with single button click
 - **Integrated viewers** - Markdown, images (no browser needed)
 - **URL recognition and clicking** in terminal output
-- **Workspace configuration** - Separate config file per workspace
+- **Workspace configuration** - Repo-local config per workspace (typically committed)
 - **Real-time test execution** visualization
 
 ---
@@ -93,12 +93,11 @@ Existing tools force workflows into constrained patterns:
 - [ ] Auto-save on change
 
 *Workspace configuration:*
-- [ ] Separate config file per workspace
+- [ ] Separate config file per workspace (repo-local, typically committed)
 - [ ] Auto-save workspace state (open terminals, documents, pane sizes, visibility)
-- [ ] Near-term: Store in platform config dir (macOS `~/Library/Application Support/terminalg/workspaces/<name>.json`, Linux `~/.config/terminalg/workspaces/<name>.json`, Windows `%APPDATA%\\terminalg\\workspaces\\<name>.json`)
-- [ ] Workspace-local: Support `.terminalg/<workspace>.json` in project repos
+- [ ] Workspace-local: `.terminalg/workspace.json` or `.terminalg/workspace-<name>.json` in project repos
 - [ ] First-time workspace: Default to file browser + terminal (same root folder)
-- [ ] App settings track all available workspaces and their config paths
+- [ ] App settings track all available workspaces and their config paths for this machine
 
 ### 4.2 Enhanced Features (Phase 4)
 
@@ -190,7 +189,7 @@ Existing tools force workflows into constrained patterns:
 
 ### 6.2 Dependencies
 
-- GPUI not published to crates.io (use git dependency)
+- GPUI is published to crates.io, but we use git tags for version parity with other Zed crates
 - Pin to stable Zed releases (tag-based versioning)
 - Minimize external dependencies
 - Use platform-specific crates where needed (PTY management)

--- a/docs/architecture/gpui-integration.md
+++ b/docs/architecture/gpui-integration.md
@@ -2,7 +2,7 @@
 
 **Status:** Phase 1 - Foundation (Planning)
 **Author:** ARCH-RTERM
-**Date:** 2025-01-25
+**Date:** 2026-01-25
 **Zed Version Target:** v0.220.3
 
 ---
@@ -761,7 +761,7 @@ incremental = true
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
-| 1.0 | 2025-01-25 | ARCH-RTERM | Initial architecture document |
+| 1.0 | 2026-01-25 | ARCH-RTERM | Initial architecture document |
 | | | | Zed v0.220.3 baseline established |
 
 ---

--- a/docs/architecture/gpui-integration.md
+++ b/docs/architecture/gpui-integration.md
@@ -23,11 +23,16 @@ This document defines the architectural strategy for integrating GPUI (Zed's GPU
 
 ### 1.1 GPUI Publication Status
 
-**Finding (2025-01-24):**
-- GPUI is **NOT published to crates.io**
-- Maintained as workspace crate in Zed monorepo: `crates/gpui`
+**Finding (2025-01-25):**
+- GPUI **IS published to crates.io** as `gpui` (v0.2.x)
+- Also maintained as workspace crate in Zed monorepo: `crates/gpui`
+- Latest crates.io version: **v0.2.2** (Oct 22, 2025)
 - Latest stable Zed release: **v0.220.3** (Jan 22, 2025)
-- Git commit: `3d02817699175909ee72bf28305997094c5cef9d`
+
+**Why we use git tag instead of crates.io:**
+- Phase 2 requires Zed's `terminal`, `settings`, and `theme` crates (NOT on crates.io)
+- All Zed crates must be from the same version for compatibility
+- Git tag pinning ensures version parity across all Zed dependencies
 
 ### 1.2 Dependency Specification
 

--- a/docs/architecture/gpui-integration.md
+++ b/docs/architecture/gpui-integration.md
@@ -2,7 +2,7 @@
 
 **Status:** Phase 1 - Foundation (Planning)
 **Author:** ARCH-RTERM
-**Date:** 2026-01-25
+**Date:** 2025-01-25
 **Zed Version Target:** v0.220.3
 
 ---
@@ -761,7 +761,7 @@ incremental = true
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
-| 1.0 | 2025-01-24 | ARCH-RTERM | Initial architecture document |
+| 1.0 | 2025-01-25 | ARCH-RTERM | Initial architecture document |
 | | | | Zed v0.220.3 baseline established |
 
 ---

--- a/docs/architecture/gpui-integration.md
+++ b/docs/architecture/gpui-integration.md
@@ -34,6 +34,11 @@ This document defines the architectural strategy for integrating GPUI (Zed's GPU
 - All Zed crates must be from the same version for compatibility
 - Git tag pinning ensures version parity across all Zed dependencies
 
+**Reference Codebase:**
+- Zed source at `../zed/` should be checked out to tag **v0.220.3**
+- Agents exploring Zed patterns MUST use this pinned version, not `main`
+- This prevents confusion from API differences between versions
+
 ### 1.2 Dependency Specification
 
 **Recommended approach:**

--- a/docs/architecture/settings-system.md
+++ b/docs/architecture/settings-system.md
@@ -20,7 +20,7 @@ This document describes TerminalG's **Phase 1 custom settings implementation**. 
 ## Project Structure
 
 ```
-your-app/
+terminalg/
 ├── src/
 │   ├── main.rs
 │   ├── settings/
@@ -29,9 +29,14 @@ your-app/
 │   │   └── ui.rs           # UI settings
 │   └── ...
 ├── Cargo.toml
-└── config/
-    └── settings.json       # User settings file
+└── .terminalg/
+    └── settings.json       # Workspace settings (repo-local)
 ```
+
+## Settings Locations
+
+- **User settings:** `~/.config/terminalg/settings.json`
+- **Workspace settings:** `.terminalg/settings.json` (in the project root)
 
 ## Cargo.toml Dependencies
 
@@ -184,7 +189,7 @@ impl SettingsStore {
     fn get_config_dir() -> Result<PathBuf> {
         dirs::config_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine config directory"))
-            .map(|p| p.join("your-app"))
+            .map(|p| p.join("terminalg"))
     }
 
     /// Get full settings file path
@@ -272,7 +277,7 @@ fn main() -> Result<()> {
 
 ## Generated settings.json
 
-First run creates this (in platform-specific config dir):
+First run creates this (in the user config dir at `~/.config/terminalg/settings.json`):
 
 ```json
 {
@@ -296,7 +301,7 @@ First run creates this (in platform-specific config dir):
 }
 ```
 
-User can edit directly, app reloads on next launch (or add notify watcher for live reload).
+User can edit directly, app reloads on next launch (or add notify watcher for live reload). Workspace overrides live in `.terminalg/settings.json` and are loaded per project.
 
 ## Key Features
 

--- a/docs/architecture/settings-system.md
+++ b/docs/architecture/settings-system.md
@@ -36,7 +36,7 @@ terminalg/
 ## Settings Locations
 
 - **User settings:** `~/.config/terminalg/settings.json`
-- **Workspace settings:** `.terminalg/settings.json` (in the project root)
+- **Workspace settings:** `.terminalg/workspace.json` or `.terminalg/workspace-<name>.json` (in the project root, typically committed)
 
 ## Cargo.toml Dependencies
 
@@ -301,7 +301,7 @@ First run creates this (in the user config dir at `~/.config/terminalg/settings.
 }
 ```
 
-User can edit directly, app reloads on next launch (or add notify watcher for live reload). Workspace overrides live in `.terminalg/settings.json` and are loaded per project.
+User can edit directly, app reloads on next launch (or add notify watcher for live reload). Workspace overrides live in `.terminalg/workspace.json` or `.terminalg/workspace-<name>.json` and are loaded per project. App settings track known workspace paths for the current machine.
 
 ## Key Features
 

--- a/docs/architecture/zed-reuse-strategy.md
+++ b/docs/architecture/zed-reuse-strategy.md
@@ -1,7 +1,7 @@
 # Zed/GPUI Reuse Strategy
 
 **Version:** 1.0
-**Last Updated:** 2026-01-25
+**Last Updated:** 2025-01-25
 **Status:** Draft
 
 ---

--- a/docs/architecture/zed-reuse-strategy.md
+++ b/docs/architecture/zed-reuse-strategy.md
@@ -20,6 +20,8 @@ This document is the **source of truth** for TerminalG's dependency on Zed crate
 | Current Version | `v0.220.3` (git tag) |
 | Version Policy | Pin to stable release tags, upgrade deliberately |
 
+**Important:** The local Zed checkout at `../zed/` MUST be at tag `v0.220.3`. AI agents exploring Zed patterns must use this pinned version, not `main`, to avoid confusion from API differences.
+
 ### 1.2 License Implications
 
 | Crate Category | License | Implication |

--- a/docs/architecture/zed-reuse-strategy.md
+++ b/docs/architecture/zed-reuse-strategy.md
@@ -1,7 +1,7 @@
 # Zed/GPUI Reuse Strategy
 
 **Version:** 1.0
-**Last Updated:** 2025-01-25
+**Last Updated:** 2026-01-25
 **Status:** Draft
 
 ---

--- a/docs/sprints/phase-1-sprint-5-design.md
+++ b/docs/sprints/phase-1-sprint-5-design.md
@@ -105,7 +105,7 @@ TerminalGApp
 ### 4.3 Settings Locations
 
 - **User settings:** `~/.config/terminalg/settings.json`
-- **Workspace settings:** `.terminalg/workspaces.json` (repo-local)
+- **Workspace settings:** `.terminalg/workspace.json` or `.terminalg/workspace-<name>.json` (repo-local, typically committed)
 
 ---
 
@@ -291,7 +291,7 @@ impl Render for WorkspaceView {
 - [ ] Implement `WorkspaceConfig` struct with serde
 - [ ] Implement `WorkspacesConfig` struct with defaults
 - [ ] Implement `WorkspaceConfigStore` with load/save
-- [ ] Use repo-local path: `.terminalg/workspaces.json`
+- [ ] Use repo-local path: `.terminalg/workspace.json` or `.terminalg/workspace-<name>.json`
 - [ ] Add unit tests for config serialization
 
 **Test checkpoint:**
@@ -561,7 +561,7 @@ mod tests {
     #[test]
     fn test_workspace_config_store_save_load() {
         let temp_dir = TempDir::new().unwrap();
-        let config_path = temp_dir.path().join("workspaces.json");
+        let config_path = temp_dir.path().join("workspace.json");
 
         // Create and save
         let mut store = WorkspaceConfigStore::new_with_path(config_path.clone()).unwrap();
@@ -576,7 +576,7 @@ mod tests {
     #[test]
     fn test_workspace_switch() {
         let temp_dir = TempDir::new().unwrap();
-        let config_path = temp_dir.path().join("workspaces.json");
+        let config_path = temp_dir.path().join("workspace.json");
         let mut store = WorkspaceConfigStore::new_with_path(config_path).unwrap();
 
         assert_eq!(store.config().active_workspace_index, 0);
@@ -600,7 +600,7 @@ mod tests {
 - [ ] Click "Hide" on terminal (middle pane) works
 - [ ] Switch workspace shows different visibility
 - [ ] Close and reopen app - state persists
-- [ ] Check `.terminalg/workspaces.json` created in repo root
+- [ ] Check `.terminalg/workspace.json` created in repo root
 - [ ] No crashes during normal usage
 - [ ] Console shows appropriate log messages
 
@@ -612,7 +612,7 @@ mod tests {
 
 - [ ] Workspace configuration loads on startup
 - [ ] Workspace configuration saves on changes
-- [ ] Config file created at `.terminalg/workspaces.json`
+- [ ] Config file created at `.terminalg/workspace.json`
 - [ ] Workspace tabs render at top of window
 - [ ] Clicking tabs switches active workspace
 - [ ] Active tab has distinct visual style

--- a/docs/sprints/phase-1-sprint-5-design.md
+++ b/docs/sprints/phase-1-sprint-5-design.md
@@ -102,6 +102,11 @@ TerminalGApp
 - **View state:** `WorkspaceView` struct holds workspace config
 - **No new globals needed** - workspace config in view state
 
+### 4.3 Settings Locations
+
+- **User settings:** `~/.config/terminalg/settings.json`
+- **Workspace settings:** `.terminalg/workspaces.json` (repo-local)
+
 ---
 
 ## 5. Data Structures
@@ -286,7 +291,7 @@ impl Render for WorkspaceView {
 - [ ] Implement `WorkspaceConfig` struct with serde
 - [ ] Implement `WorkspacesConfig` struct with defaults
 - [ ] Implement `WorkspaceConfigStore` with load/save
-- [ ] Use platform-specific paths (match settings pattern)
+- [ ] Use repo-local path: `.terminalg/workspaces.json`
 - [ ] Add unit tests for config serialization
 
 **Test checkpoint:**
@@ -595,7 +600,7 @@ mod tests {
 - [ ] Click "Hide" on terminal (middle pane) works
 - [ ] Switch workspace shows different visibility
 - [ ] Close and reopen app - state persists
-- [ ] Check workspaces.json created in config dir
+- [ ] Check `.terminalg/workspaces.json` created in repo root
 - [ ] No crashes during normal usage
 - [ ] Console shows appropriate log messages
 
@@ -607,7 +612,7 @@ mod tests {
 
 - [ ] Workspace configuration loads on startup
 - [ ] Workspace configuration saves on changes
-- [ ] Config file created in platform-specific location
+- [ ] Config file created at `.terminalg/workspaces.json`
 - [ ] Workspace tabs render at top of window
 - [ ] Clicking tabs switches active workspace
 - [ ] Active tab has distinct visual style
@@ -675,5 +680,5 @@ mod tests {
 ---
 
 **Document Status:** Ready for Implementation
-**Created:** 2026-01-24
+**Created:** 2025-01-25
 **Author:** rust-architect agent + manual review

--- a/docs/sprints/phase-1-sprint-5-design.md
+++ b/docs/sprints/phase-1-sprint-5-design.md
@@ -680,5 +680,5 @@ mod tests {
 ---
 
 **Document Status:** Ready for Implementation
-**Created:** 2025-01-25
+**Created:** 2026-01-25
 **Author:** rust-architect agent + manual review

--- a/docs/sprints/phase-1-sprint-5-design.md
+++ b/docs/sprints/phase-1-sprint-5-design.md
@@ -5,6 +5,9 @@
 **Parallel:** No (final sprint in Phase 1)
 **Status:** Not Started
 
+**Branch:** `feature/sprint-1-5-workspace-tabs`
+**Worktree:** `/Users/randlee/Documents/github/terminalg-worktrees/feature/sprint-1-5-workspace-tabs`
+
 > **Note:** This sprint uses TerminalG's custom settings and theme systems (Phase 1 approach).
 > Phase 2 will migrate to Zed's `settings` and `theme` crates as git dependencies.
 > See `docs/architecture/zed-reuse-strategy.md` for the complete dependency strategy.


### PR DESCRIPTION
## Summary
- Add concurrency group based on workflow + branch/PR
- Enable cancel-in-progress to stop stale runs on new pushes
- Remove develop from push triggers (PRs handle develop branch)

## Problem
Previously, pushing to `develop` while a PR was open would trigger both:
- `push` event (develop in push branches list)
- `pull_request` event (PR head SHA changed)

This caused 10 jobs to run instead of 5.

## Solution
- Concurrency groups cancel redundant runs
- Only `main` triggers on push (post-merge CI)
- PRs still trigger on both `main` and `develop` targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)