### PR TITLE
feat(terminal): Sprint 2.3 - URL Recognition & Clicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6092,6 +6092,7 @@ dependencies = [
  "futures",
  "gpui",
  "notify 6.1.1",
+ "open",
  "serde",
  "serde_json",
  "settings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
+# URL launching (for hyperlink support)
+open = "5.0"
+
 # Markdown & Text (Phase 3)
 # pulldown-cmark = "0.9"
 # rope = "0.1"

--- a/docs/sprints/phase-2-sprint-3-design.md
+++ b/docs/sprints/phase-2-sprint-3-design.md
@@ -1,0 +1,705 @@
+# Phase 2 Sprint 2.3 Design: URL Recognition & Clicking
+
+**Version:** 1.0
+**Created:** 2026-01-26
+**Status:** Ready for Implementation
+**Prerequisite:** Sprint 2.2 Complete (Terminal Pane Integration)
+**Estimated Duration:** 6-10 hours
+
+---
+
+## Development Environment
+
+| Item | Value |
+|------|-------|
+| **Worktree Path** | `/Users/randlee/Documents/github/terminalg-worktrees/feature/sprint-2-3-url-recognition` |
+| **Branch** | `feature/sprint-2-3-url-recognition` |
+| **Base Branch** | `develop` |
+| **Created** | 2026-01-26 |
+
+```bash
+# Navigate to worktree
+cd /Users/randlee/Documents/github/terminalg-worktrees/feature/sprint-2-3-url-recognition
+
+# Verify branch
+git branch --show-current
+# → feature/sprint-2-3-url-recognition
+```
+
+---
+
+## 1. Overview
+
+Sprint 2.3 adds URL detection and clicking functionality to TerminalG's terminal pane by leveraging Zed's existing hyperlink infrastructure. This sprint requires **minimal new code** since Zed's terminal crate already provides:
+
+- URL regex pattern matching (`terminal_hyperlinks.rs`)
+- Mouse event handling (`mouse_move`, `mouse_down`, `mouse_up`)
+- Hover state tracking (`HoveredWord`, `last_hovered_word`)
+- Events for opening URLs (`Event::Open`)
+
+### Key Deliverables
+
+1. URL regex configuration in `TerminalBuilder`
+2. Mouse event wiring to Zed's terminal methods
+3. Event subscription for `Open` and `NewNavigationTarget`
+4. Visual feedback for hyperlinks (hover state + cursor change)
+5. Browser launching for clicked URLs
+
+### Success Criteria
+
+- Ctrl/Cmd+hover displays URL in status bar
+- Ctrl/Cmd+click opens URLs in default browser
+- Works with http://, https://, git://, ssh://, file://, etc.
+- Hover state visible via cursor change
+- No false positives on terminal text
+
+---
+
+## 2. Architecture Analysis
+
+### 2.1 Zed's URL Detection System
+
+**Three-Layer Detection** (`terminal_hyperlinks.rs`):
+```
+Layer 1: ANSI Hyperlinks (OSC 8 sequences)
+   ↓ Not found?
+Layer 2: URL_REGEX pattern
+   Pattern: (http|https|git|ssh|file|...):// + valid chars
+   Sanitizes trailing punctuation (., ,, :, ;)
+   ↓ Not found?
+Layer 3: Path Regex (custom patterns)
+   Configured via path_hyperlink_regexes
+```
+
+**URL_REGEX Pattern** (line 20 of `terminal_hyperlinks.rs`):
+```rust
+const URL_REGEX: &str = r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩`']+"#;
+```
+
+### 2.2 Zed's Mouse Event Flow
+
+```
+User Mouse Move (Ctrl/Cmd held)
+    ↓ GPUI MouseMoveEvent
+Terminal.mouse_move()
+    ↓ Checks modifiers.secondary()
+    ↓ Throttles (5px spatial, 100ms temporal)
+InternalEvent::FindHyperlink(position, open=false)
+    ↓
+terminal_hyperlinks::find_from_grid_point()
+    ↓ Returns (url, is_url, match_range)
+Terminal.process_hyperlink()
+    ↓ Updates last_hovered_word
+Event::NewNavigationTarget(Some(MaybeNavigationTarget::Url))
+    ↑ Emitted to subscribers
+
+User Mouse Down (Ctrl/Cmd held)
+    ↓
+Terminal.mouse_down()
+    ↓ Stores hyperlink at click position
+mouse_down_hyperlink = find_from_grid_point(...)
+
+User Mouse Up (Ctrl/Cmd held)
+    ↓
+Terminal.mouse_up()
+    ↓ Compares stored hyperlink with current
+    ↓ If same, open URL
+InternalEvent::ProcessHyperlink(..., open=true)
+    ↓
+Event::Open(MaybeNavigationTarget::Url(url))
+    ↑ Emitted to subscribers
+```
+
+### 2.3 Current TerminalG State
+
+**Rendering** (`src/terminal/pane.rs` lines 254-314):
+- Extracts plain text from `content.cells`
+- **Missing:** Cell styling, hyperlink underlines
+- **Missing:** Access to `last_hovered_word` for hover effects
+
+**Event Handling** (lines 122-151):
+- Handles: `TitleChanged`, `BreadcrumbsChanged`, `CloseTerminal`, `Wakeup`, `Bell`
+- **Missing:** `Open`, `NewNavigationTarget`
+
+**Input Handling**:
+- Keyboard: ✅ Implemented via `handle_key_down()`
+- Mouse: ❌ Not implemented
+
+**URL Configuration** (line 83):
+```rust
+Vec::new(), // path_hyperlink_regexes <- EMPTY!
+```
+
+---
+
+## 3. Implementation Blueprint
+
+### 3.1 Phase 1: URL Regex Configuration (1 hour)
+
+**Objective:** Pass URL patterns to `TerminalBuilder` for path detection.
+
+**File:** `src/terminal/pane.rs`
+
+**Changes:**
+
+1. Add default path regex patterns (near top of file after imports):
+
+```rust
+// Add near top of file (after imports)
+const DEFAULT_PATH_REGEXES: &[&str] = &[
+    // File paths with optional line:col
+    r"[a-zA-Z0-9._\-~/]+/[a-zA-Z0-9._\-~/]+(?::\d+)?(?::\d+)?",
+    // GitHub-style file references
+    r"[\w\-/\.]+\.(?:rs|js|ts|py|go|java|c|cpp|h|md|txt)",
+];
+```
+
+2. In `spawn_terminal()` method, replace line 83:
+
+```rust
+// Before line 75, prepare regex patterns
+let path_hyperlink_regexes: Vec<String> = DEFAULT_PATH_REGEXES
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+// Replace line 83 with:
+path_hyperlink_regexes, // Use configured patterns (instead of Vec::new())
+```
+
+**Testing:**
+- Terminal spawns without errors
+- No change to existing behavior yet
+
+---
+
+### 3.2 Phase 2: Mouse Event Wiring (2-3 hours)
+
+**Objective:** Connect GPUI mouse events to Zed's terminal mouse handlers.
+
+**File:** `src/terminal/pane.rs`
+
+**Changes:**
+
+1. **Add mouse event handlers** (after `handle_key_down()` at line 203):
+
+```rust
+/// Handle mouse move events
+fn handle_mouse_move(
+    &mut self,
+    event: &gpui::MouseMoveEvent,
+    _window: &mut Window,
+    cx: &mut Context<Self>,
+) {
+    if let Some(tab) = self.active_tab_mut() {
+        tab.terminal.update(cx, |terminal, cx| {
+            terminal.mouse_move(event, cx);
+        });
+        cx.notify();
+    }
+}
+
+/// Handle mouse down events
+fn handle_mouse_down(
+    &mut self,
+    event: &gpui::MouseDownEvent,
+    _window: &mut Window,
+    cx: &mut Context<Self>,
+) {
+    if let Some(tab) = self.active_tab_mut() {
+        tab.terminal.update(cx, |terminal, cx| {
+            terminal.mouse_down(event, cx);
+        });
+        cx.notify();
+    }
+}
+
+/// Handle mouse up events
+fn handle_mouse_up(
+    &mut self,
+    event: &gpui::MouseUpEvent,
+    _window: &mut Window,
+    cx: &mut Context<Self>,
+) {
+    if let Some(tab) = self.active_tab_mut() {
+        tab.terminal.update(cx, |terminal, cx| {
+            terminal.mouse_up(event, cx);
+        });
+        cx.notify();
+    }
+}
+```
+
+2. **Wire events to render** (modify `render()` method):
+
+```rust
+fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    div()
+        .track_focus(&self.focus_handle)
+        .flex()
+        .flex_col()
+        .size_full()
+        .on_key_down(cx.listener(Self::handle_key_down))
+        .on_mouse_move(cx.listener(Self::handle_mouse_move))  // ADD
+        .on_mouse_down(cx.listener(Self::handle_mouse_down))  // ADD
+        .on_mouse_up(cx.listener(Self::handle_mouse_up))      // ADD
+        .child(self.render_terminal_content(cx))
+        .child(self.render_tabs(cx))
+}
+```
+
+**Testing:**
+- Mouse events logged via `tracing::debug!`
+- Ctrl/Cmd+hover triggers `FindHyperlink` (check logs)
+- No crashes or panics
+
+---
+
+### 3.3 Phase 3: Event Handling - Open URLs (2-3 hours)
+
+**Objective:** Subscribe to `Open` events and launch browser.
+
+**File:** `src/terminal/pane.rs`
+
+**Changes:**
+
+1. **Extend event handler** (modify `handle_terminal_event()`):
+
+```rust
+fn handle_terminal_event(&mut self, event: &TerminalEvent, cx: &mut Context<Self>) {
+    match event {
+        TerminalEvent::TitleChanged | TerminalEvent::BreadcrumbsChanged => {
+            cx.emit(TerminalPaneEvent::TitleChanged);
+            cx.notify();
+        }
+        TerminalEvent::CloseTerminal => {
+            // ... existing code ...
+        }
+        TerminalEvent::Wakeup => {
+            cx.notify();
+        }
+        TerminalEvent::Bell => {
+            tracing::debug!("Terminal bell");
+        }
+        // ADD: Handle URL open events
+        TerminalEvent::Open(target) => {
+            self.handle_open_target(target, cx);
+        }
+        // ADD: Handle hover state changes
+        TerminalEvent::NewNavigationTarget(target) => {
+            self.handle_navigation_target(target, cx);
+        }
+        _ => {}
+    }
+}
+```
+
+2. **Add helper methods** (after `handle_terminal_event()`):
+
+```rust
+/// Handle opening a URL or path
+fn handle_open_target(
+    &mut self,
+    target: &terminal::MaybeNavigationTarget,
+    cx: &mut Context<Self>,
+) {
+    match target {
+        terminal::MaybeNavigationTarget::Url(url) => {
+            tracing::info!("Opening URL: {}", url);
+            if let Err(e) = open::that(url) {
+                tracing::error!("Failed to open URL {}: {}", url, e);
+            }
+        }
+        terminal::MaybeNavigationTarget::PathLike(path_target) => {
+            // Future: implement path navigation
+            tracing::info!("Path navigation not yet implemented: {}", path_target.maybe_path);
+        }
+    }
+}
+
+/// Handle navigation target hover state
+fn handle_navigation_target(
+    &mut self,
+    target: &Option<terminal::MaybeNavigationTarget>,
+    cx: &mut Context<Self>,
+) {
+    // Future: show tooltip or status indicator
+    if let Some(terminal::MaybeNavigationTarget::Url(url)) = target {
+        tracing::debug!("Hovering URL: {}", url);
+    }
+    cx.notify();
+}
+```
+
+3. **Add `open` crate dependency** (`Cargo.toml`):
+
+```toml
+[dependencies]
+open = "5.0"  # For cross-platform URL launching
+```
+
+**Testing:**
+- Ctrl/Cmd+click on `https://example.com` opens browser
+- Works with http://, https://, git://, ssh://
+- Error logged if URL malformed
+- No crashes
+
+---
+
+### 3.4 Phase 4: Visual Styling - Hover Effects (2-3 hours)
+
+**Objective:** Render hover state feedback (simplified approach).
+
+**Key Decision:** Instead of rewriting cell-by-cell rendering, use simplified visual feedback:
+- Display hovered URL in terminal footer
+- Change cursor to pointer on hover
+- Defer full underline rendering to future sprint
+
+**File:** `src/terminal/pane.rs`
+
+**Changes:**
+
+1. **Enhance rendering** (modify `render_terminal_content()`):
+
+```rust
+/// Render the terminal content area with hover feedback
+fn render_terminal_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    let theme = cx.theme();
+
+    if let Some(tab) = self.tabs.get(self.active_tab) {
+        let terminal = tab.terminal.read(cx);
+        let content = terminal.last_content();
+
+        // Get hovered URL for display
+        let hovered_url = content.last_hovered_word.as_ref()
+            .map(|hw| hw.word.clone());
+
+        // Simple text rendering (existing code)
+        let mut lines: Vec<String> = Vec::new();
+        // ... existing cell iteration code ...
+
+        div()
+            .flex_1()
+            .w_full()
+            .relative()
+            .bg(theme.colors().terminal_background)
+            .text_color(theme.colors().terminal_foreground)
+            .font_family("Menlo")
+            .text_sm()
+            .p_2()
+            .overflow_hidden()
+            .children(lines.into_iter().map(|line| {
+                div().child(if line.is_empty() { " ".to_string() } else { line })
+            }))
+            // ADD: Show hovered URL in footer
+            .when(hovered_url.is_some(), |d| {
+                d.child(
+                    div()
+                        .absolute()
+                        .bottom_0()
+                        .left_0()
+                        .right_0()
+                        .px_2()
+                        .py_1()
+                        .bg(theme.colors().element_background)
+                        .border_t_1()
+                        .border_color(theme.colors().border)
+                        .text_xs()
+                        .text_color(theme.colors().link_text_hover)
+                        .child(format!("🔗 {}", hovered_url.unwrap_or_default()))
+                )
+            })
+    } else {
+        // ... loading state ...
+    }
+}
+```
+
+2. **Add cursor change on hover** (modify `render()`):
+
+```rust
+fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    // Check if hovering over a URL
+    let hovering_url = self.tabs.get(self.active_tab)
+        .and_then(|tab| {
+            tab.terminal.read(cx)
+                .last_content()
+                .last_hovered_word
+                .as_ref()
+                .map(|_| true)
+        })
+        .unwrap_or(false);
+
+    div()
+        .track_focus(&self.focus_handle)
+        .flex()
+        .flex_col()
+        .size_full()
+        .when(hovering_url, |d| d.cursor_pointer())  // ADD
+        .on_key_down(cx.listener(Self::handle_key_down))
+        .on_mouse_move(cx.listener(Self::handle_mouse_move))
+        .on_mouse_down(cx.listener(Self::handle_mouse_down))
+        .on_mouse_up(cx.listener(Self::handle_mouse_up))
+        .child(self.render_terminal_content(cx))
+        .child(self.render_tabs(cx))
+}
+```
+
+**Future Enhancement (Sprint 2.4+):**
+- Implement proper cell-by-cell rendering with styled spans
+- Apply `link_style` with underline decoration
+- Match Zed's full hyperlink visual appearance
+
+**Testing:**
+- Ctrl/Cmd+hover shows URL at bottom of terminal
+- Cursor changes to pointer on hover
+- URL disappears when Ctrl/Cmd released
+
+---
+
+## 4. Data Flow Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        User Interaction                          │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ Ctrl/Cmd + Mouse Move over "https://example.com"
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  TerminalPane.handle_mouse_move()                                │
+│  - Forward to Terminal.mouse_move()                              │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ MouseMoveEvent { modifiers.secondary: true }
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  Terminal.mouse_move() [Zed]                                     │
+│  - Check modifiers.secondary() (Ctrl/Cmd)                        │
+│  - Throttle: 5px spatial, 100ms temporal                         │
+│  - Create InternalEvent::FindHyperlink(position, open=false)     │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ InternalEvent::FindHyperlink
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  Terminal.process_internal_event() [Zed]                         │
+│  - Convert pixel position to grid point                          │
+│  - Call terminal_hyperlinks::find_from_grid_point()              │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ grid_point, regex_searches
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  terminal_hyperlinks::find_from_grid_point() [Zed]               │
+│  1. Check ANSI hyperlinks (OSC 8)                                │
+│  2. Search URL_REGEX pattern                                     │
+│  3. Search path_hyperlink_regexes                                │
+│  4. Sanitize trailing punctuation                               │
+│  Returns: Some((url, is_url, match_range))                      │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ ("https://example.com", true, 10..=29)
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  Terminal.process_hyperlink() [Zed]                              │
+│  - Update last_content.last_hovered_word = HoveredWord {         │
+│      word: "https://example.com",                                │
+│      word_match: 10..=29,                                        │
+│      id: unique_id                                               │
+│    }                                                             │
+│  - Emit Event::NewNavigationTarget(Some(Url(...)))              │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ Event::NewNavigationTarget
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  TerminalPane.handle_terminal_event()                            │
+│  - Call handle_navigation_target()                               │
+│  - Log: "Hovering URL: https://example.com"                     │
+│  - cx.notify() triggers re-render                               │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ cx.notify()
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  TerminalPane.render()                                           │
+│  - Read last_hovered_word from terminal content                  │
+│  - Set cursor_pointer() when hovering URL                        │
+│  - Display URL in bottom status bar                             │
+└──────────────────────────────────────────────────────────────────┘
+
+═══════════════════════════════════════════════════════════════════
+
+User Action: Ctrl/Cmd + Click
+
+┌──────────────────────────────────────────────────────────────────┐
+│  TerminalPane.handle_mouse_down()                                │
+│  - Forward to Terminal.mouse_down()                              │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  Terminal.mouse_down() [Zed]                                     │
+│  - Find hyperlink at click position                              │
+│  - Store in mouse_down_hyperlink: Some((...))                    │
+└──────────────────────────────────────────────────────────────────┘
+
+User Action: Ctrl/Cmd + Release
+
+┌──────────────────────────────────────────────────────────────────┐
+│  TerminalPane.handle_mouse_up()                                  │
+│  - Forward to Terminal.mouse_up()                                │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  Terminal.mouse_up() [Zed]                                       │
+│  - Find hyperlink at release position                            │
+│  - Compare with stored mouse_down_hyperlink                      │
+│  - If same: Create InternalEvent::ProcessHyperlink(..., true)    │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ InternalEvent::ProcessHyperlink(open=true)
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  Terminal.process_hyperlink() [Zed]                              │
+│  - Emit Event::Open(MaybeNavigationTarget::Url(...))            │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ Event::Open
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  TerminalPane.handle_terminal_event()                            │
+│  - Call handle_open_target()                                     │
+│  - Extract URL string                                            │
+│  - Call open::that(url)                                          │
+└───────────────┬──────────────────────────────────────────────────┘
+                │
+                │ open::that("https://example.com")
+                ↓
+┌──────────────────────────────────────────────────────────────────┐
+│  System Default Browser                                          │
+│  - Browser launched with URL                                     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Build Sequence Checklist
+
+### Phase 1: URL Regex Configuration (1 hour)
+- [ ] Add `DEFAULT_PATH_REGEXES` constant to `pane.rs`
+- [ ] Modify `spawn_terminal()` to pass regex patterns
+- [ ] Test: Terminal spawns without errors
+- [ ] Test: No change to existing behavior
+- [ ] Commit: "feat: configure URL path regexes for terminal hyperlinks"
+
+### Phase 2: Mouse Event Wiring (2-3 hours)
+- [ ] Add `handle_mouse_move()` method
+- [ ] Add `handle_mouse_down()` method
+- [ ] Add `handle_mouse_up()` method
+- [ ] Wire events in `render()` method
+- [ ] Test: Mouse events logged via tracing
+- [ ] Test: Ctrl/Cmd+hover triggers FindHyperlink (check logs)
+- [ ] Test: No crashes or panics
+- [ ] Commit: "feat: wire mouse events to terminal hyperlink detection"
+
+### Phase 3: Event Handling - Open URLs (2-3 hours)
+- [ ] Add `open` crate to `Cargo.toml`
+- [ ] Extend `handle_terminal_event()` with `Open` case
+- [ ] Extend `handle_terminal_event()` with `NewNavigationTarget` case
+- [ ] Add `handle_open_target()` method
+- [ ] Add `handle_navigation_target()` method
+- [ ] Test: Ctrl/Cmd+click on `https://example.com` opens browser
+- [ ] Test: Works with http://, https://, git://, ssh://
+- [ ] Test: Error logged if URL malformed
+- [ ] Test: No crashes
+- [ ] Commit: "feat: implement URL opening in default browser"
+
+### Phase 4: Visual Styling - Hover Effects (2-3 hours)
+- [ ] Modify `render_terminal_content()` to show hovered URL
+- [ ] Add cursor pointer style when hovering URL
+- [ ] Test: Ctrl/Cmd+hover shows URL at bottom of terminal
+- [ ] Test: Cursor changes to pointer on hover
+- [ ] Test: URL disappears when Ctrl/Cmd released
+- [ ] Commit: "feat: add visual feedback for URL hover state"
+
+### Final Integration (1 hour)
+- [ ] Run full test suite: `cargo test`
+- [ ] Run clippy: `cargo clippy -- -D warnings`
+- [ ] Manual testing: various URL types
+- [ ] Update MASTER-PLAN.md: Sprint 2.3 complete
+- [ ] Commit: "docs: mark Sprint 2.3 complete"
+
+---
+
+## 6. Testing Plan
+
+### Manual Testing Checklist
+
+**URL Types:**
+- [ ] `https://example.com` - HTTPS URL
+- [ ] `http://example.com` - HTTP URL
+- [ ] `git://github.com/user/repo` - Git URL
+- [ ] `ssh://user@host.com` - SSH URL
+- [ ] `file:///path/to/file` - File URL
+- [ ] `mailto:user@example.com` - Mailto URL
+- [ ] `ftp://ftp.example.com` - FTP URL
+
+**Edge Cases:**
+- [ ] URL with trailing period: `https://example.com.` → opens `https://example.com`
+- [ ] URL with trailing comma: `https://example.com,` → opens `https://example.com`
+- [ ] URL in parentheses: `(https://example.com)` → opens `https://example.com`
+- [ ] URL with query params: `https://example.com?foo=bar`
+- [ ] URL with fragment: `https://example.com#section`
+- [ ] URL with port: `http://localhost:8080`
+
+**Interaction Tests:**
+- [ ] Hover without Ctrl/Cmd - no effect
+- [ ] Hover with Ctrl/Cmd - URL highlighted, cursor pointer
+- [ ] Click without Ctrl/Cmd - normal terminal click
+- [ ] Click with Ctrl/Cmd - browser opens
+- [ ] Drag with Ctrl/Cmd held - no URL open (movement threshold)
+- [ ] Release Ctrl/Cmd - highlighting disappears
+
+---
+
+## 7. Risk Assessment
+
+| Risk | Severity | Likelihood | Mitigation |
+|------|----------|------------|------------|
+| Mouse events interfere with terminal selection | Medium | Medium | Zed's implementation handles this - only Ctrl/Cmd+click |
+| URL regex causes performance issues | Low | Low | Throttled by Zed (5px, 100ms) - proven in production |
+| False positive URL detection | Low | Medium | Use Zed's tested URL_REGEX - 447 test cases |
+| Browser fails to open | Low | Medium | Log error, continue execution - graceful degradation |
+| Complex rendering with underlines | High | Medium | Deferred to future sprint - use simple hover feedback |
+
+---
+
+## 8. References
+
+### Zed Source Files (Reference)
+- `zed/crates/terminal/src/terminal.rs`
+  - Lines 1725-1977: Mouse event handling
+  - Lines 1165-1228: Hyperlink detection and processing
+  - Lines 790-794: HoveredWord struct
+- `zed/crates/terminal/src/terminal_hyperlinks.rs`
+  - Line 20: URL_REGEX pattern
+  - Lines 69-155: find_from_grid_point() implementation
+
+### TerminalG Source Files (Modify)
+- `src/terminal/pane.rs`
+  - Lines 75-90: TerminalBuilder configuration
+  - Lines 122-151: Event handling
+  - Lines 254-314: Terminal content rendering
+  - Lines 325-336: Render method
+
+### External Libraries
+- **open crate:** https://docs.rs/open/5.0.0/open/
+  - Cross-platform URL launching
+
+---
+
+**Document Status:** Ready for Implementation
+**Next Steps:** Create feature branch, begin Phase 1 implementation

--- a/src/terminal/pane.rs
+++ b/src/terminal/pane.rs
@@ -5,14 +5,14 @@
 
 use collections::HashMap;
 use gpui::{
-    div, prelude::*, px, App, Context, EventEmitter, FocusHandle, Focusable, IntoElement,
-    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Render, Styled,
-    Subscription, Task, Window,
+    div, prelude::*, px, App, Context, Entity, EventEmitter, FocusHandle, Focusable, IntoElement,
+    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Render, Styled, Task,
+    Window,
 };
 use settings::Settings;
 use std::path::PathBuf;
 use terminal::{
-    terminal_settings::TerminalSettings, Event as TerminalEvent, MaybeNavigationTarget,
+    terminal_settings::TerminalSettings, Event as TerminalEvent, MaybeNavigationTarget, Terminal,
     TerminalBuilder,
 };
 use theme::ActiveTheme;
@@ -46,8 +46,6 @@ pub struct TerminalPane {
     active_tab: usize,
     /// Focus handle for keyboard input
     focus_handle: FocusHandle,
-    /// Subscriptions to terminal events
-    subscriptions: Vec<Subscription>,
 }
 
 impl TerminalPane {
@@ -58,7 +56,6 @@ impl TerminalPane {
             tabs: Vec::new(),
             active_tab: 0,
             focus_handle,
-            subscriptions: Vec::new(),
         };
 
         // Spawn initial terminal
@@ -116,17 +113,19 @@ impl TerminalPane {
                         // Create the terminal entity and subscribe to events
                         let terminal = cx.new(|cx| builder.subscribe(cx));
 
-                        let tab = TerminalTab::new(terminal.clone(), working_dir, cx);
+                        // Subscribe to terminal events - pass terminal entity to handler
+                        let subscription = cx.subscribe(
+                            &terminal,
+                            |pane: &mut Self, terminal: Entity<Terminal>, event, cx| {
+                                pane.handle_terminal_event(&terminal, event, cx);
+                            },
+                        );
 
-                        // Subscribe to terminal events
-                        let subscription =
-                            cx.subscribe(&terminal, |pane: &mut Self, _terminal, event, cx| {
-                                pane.handle_terminal_event(event, cx);
-                            });
+                        // Create tab with subscription (subscription moves into tab, auto-dropped when tab removed)
+                        let tab = TerminalTab::new(terminal.clone(), working_dir, subscription, cx);
 
                         pane.tabs.push(tab);
                         pane.active_tab = pane.tabs.len() - 1;
-                        pane.subscriptions.push(subscription);
                         cx.notify();
                     });
                 }
@@ -139,16 +138,22 @@ impl TerminalPane {
     }
 
     /// Handle terminal events
-    fn handle_terminal_event(&mut self, event: &TerminalEvent, cx: &mut Context<Self>) {
+    fn handle_terminal_event(
+        &mut self,
+        terminal: &Entity<Terminal>,
+        event: &TerminalEvent,
+        cx: &mut Context<Self>,
+    ) {
         match event {
             TerminalEvent::TitleChanged | TerminalEvent::BreadcrumbsChanged => {
                 cx.emit(TerminalPaneEvent::TitleChanged);
                 cx.notify();
             }
             TerminalEvent::CloseTerminal => {
-                // Remove the active terminal tab
-                if !self.tabs.is_empty() {
-                    self.tabs.remove(self.active_tab);
+                // Find the tab that owns this terminal and remove it (not just active tab)
+                if let Some(idx) = self.tabs.iter().position(|tab| &tab.terminal == terminal) {
+                    self.tabs.remove(idx);
+                    // Adjust active_tab if needed
                     if self.active_tab >= self.tabs.len() && !self.tabs.is_empty() {
                         self.active_tab = self.tabs.len() - 1;
                     }
@@ -189,8 +194,28 @@ impl TerminalPane {
                 }
             }
             MaybeNavigationTarget::PathLike(path_target) => {
-                // Future: implement path navigation
-                tracing::info!("Path navigation requested: {:?}", path_target.maybe_path);
+                // Strip optional :line:col suffix (open::that can't use it)
+                let base_path = path_target
+                    .maybe_path
+                    .split(':')
+                    .next()
+                    .unwrap_or(&path_target.maybe_path);
+
+                let path = std::path::Path::new(base_path);
+
+                // Resolve relative paths using terminal's working directory
+                let full_path = if path.is_absolute() {
+                    path.to_path_buf()
+                } else if let Some(terminal_dir) = &path_target.terminal_dir {
+                    terminal_dir.join(path)
+                } else {
+                    path.to_path_buf()
+                };
+
+                tracing::info!("Opening path: {:?}", full_path);
+                if let Err(e) = open::that(&full_path) {
+                    tracing::error!("Failed to open path {:?}: {}", full_path, e);
+                }
             }
         }
     }

--- a/src/terminal/pane.rs
+++ b/src/terminal/pane.rs
@@ -117,8 +117,8 @@ impl TerminalPane {
             alternate_scroll,
             max_scroll_history,
             path_hyperlink_regexes, // Use configured patterns
-            500,        // path_hyperlink_timeout_ms
-            false,      // is_remote_terminal
+            500,                    // path_hyperlink_timeout_ms
+            false,                  // is_remote_terminal
             window_id,
             None, // completion_tx
             cx,
@@ -139,7 +139,7 @@ impl TerminalPane {
                                 pane.handle_terminal_event(&terminal, event, cx);
                             });
 
-                        let tab = TerminalTab::new(terminal.clone(), subscription, working_dir, cx);
+                        let tab = TerminalTab::new(terminal.clone(), working_dir, subscription, cx);
 
                         let tabs = pane
                             .tabs_by_workspace
@@ -207,13 +207,7 @@ impl TerminalPane {
                 }
             }
             MaybeNavigationTarget::PathLike(path_target) => {
-                // Strip optional :line:col suffix (open::that can't use it)
-                let base_path = path_target
-                    .maybe_path
-                    .split(':')
-                    .next()
-                    .unwrap_or(&path_target.maybe_path);
-
+                let base_path = strip_line_col_suffix(&path_target.maybe_path);
                 let path = std::path::Path::new(base_path);
 
                 // Resolve relative paths using terminal's working directory
@@ -584,9 +578,26 @@ fn clamp_active_index(active_index: usize, len: usize) -> Option<usize> {
     }
 }
 
+fn strip_line_col_suffix(path: &str) -> &str {
+    let Some((head, tail)) = path.rsplit_once(':') else {
+        return path;
+    };
+    if !tail.chars().all(|c| c.is_ascii_digit()) {
+        return path;
+    }
+    let Some((head2, tail2)) = head.rsplit_once(':') else {
+        return head;
+    };
+    if tail2.chars().all(|c| c.is_ascii_digit()) {
+        head2
+    } else {
+        head
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::clamp_active_index;
+    use super::{clamp_active_index, strip_line_col_suffix};
 
     #[test]
     fn clamp_active_index_handles_empty() {
@@ -603,5 +614,37 @@ mod tests {
     #[test]
     fn clamp_active_index_out_of_bounds() {
         assert_eq!(clamp_active_index(5, 2), Some(1));
+    }
+
+    #[test]
+    fn strip_line_col_suffix_no_suffix() {
+        assert_eq!(strip_line_col_suffix("src/main.rs"), "src/main.rs");
+    }
+
+    #[test]
+    fn strip_line_col_suffix_line_only() {
+        assert_eq!(strip_line_col_suffix("src/main.rs:12"), "src/main.rs");
+    }
+
+    #[test]
+    fn strip_line_col_suffix_line_col() {
+        assert_eq!(strip_line_col_suffix("src/main.rs:12:5"), "src/main.rs");
+    }
+
+    #[test]
+    fn strip_line_col_suffix_windows_drive() {
+        assert_eq!(
+            strip_line_col_suffix("C:\\path\\file.rs"),
+            "C:\\path\\file.rs"
+        );
+        assert_eq!(
+            strip_line_col_suffix("C:\\path\\file.rs:12:3"),
+            "C:\\path\\file.rs"
+        );
+    }
+
+    #[test]
+    fn strip_line_col_suffix_non_numeric_tail() {
+        assert_eq!(strip_line_col_suffix("/tmp/foo:bar"), "/tmp/foo:bar");
     }
 }

--- a/src/terminal/pane.rs
+++ b/src/terminal/pane.rs
@@ -100,8 +100,8 @@ impl TerminalPane {
             alternate_scroll,
             max_scroll_history,
             path_hyperlink_regexes, // Use configured patterns
-            500,        // path_hyperlink_timeout_ms
-            false,      // is_remote_terminal
+            500,                    // path_hyperlink_timeout_ms
+            false,                  // is_remote_terminal
             window_id,
             None, // completion_tx
             cx,
@@ -190,10 +190,7 @@ impl TerminalPane {
             }
             MaybeNavigationTarget::PathLike(path_target) => {
                 // Future: implement path navigation
-                tracing::info!(
-                    "Path navigation requested: {:?}",
-                    path_target.maybe_path
-                );
+                tracing::info!("Path navigation requested: {:?}", path_target.maybe_path);
             }
         }
     }

--- a/src/terminal/pane.rs
+++ b/src/terminal/pane.rs
@@ -16,6 +16,15 @@ use util::shell::Shell;
 
 use crate::terminal::tab::TerminalTab;
 
+/// Default regex patterns for detecting file paths in terminal output.
+/// Note: These can be noisy. Consider gating behind a setting if false positives are an issue.
+const DEFAULT_PATH_REGEXES: &[&str] = &[
+    // File paths with optional line:col
+    r"[a-zA-Z0-9._\-~/]+/[a-zA-Z0-9._\-~/]+(?::\d+)?(?::\d+)?",
+    // Common source file extensions
+    r"[\w\-/\.]+\.(?:rs|js|ts|py|go|java|c|cpp|h|md|txt)",
+];
+
 /// Events emitted by the terminal pane
 #[derive(Clone, Debug)]
 pub enum TerminalPaneEvent {
@@ -71,6 +80,12 @@ impl TerminalPane {
         // Clone working_directory for the async closure
         let working_dir = working_directory.clone();
 
+        // Prepare path hyperlink regex patterns
+        let path_hyperlink_regexes: Vec<String> = DEFAULT_PATH_REGEXES
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
         // Spawn terminal asynchronously
         let terminal_task: Task<anyhow::Result<TerminalBuilder>> = TerminalBuilder::new(
             working_directory,
@@ -80,7 +95,7 @@ impl TerminalPane {
             cursor_shape,
             alternate_scroll,
             max_scroll_history,
-            Vec::new(), // path_hyperlink_regexes
+            path_hyperlink_regexes, // Use configured patterns
             500,        // path_hyperlink_timeout_ms
             false,      // is_remote_terminal
             window_id,

--- a/src/terminal/pane.rs
+++ b/src/terminal/pane.rs
@@ -6,11 +6,15 @@
 use collections::HashMap;
 use gpui::{
     div, prelude::*, px, App, Context, EventEmitter, FocusHandle, Focusable, IntoElement,
-    KeyDownEvent, Render, Styled, Subscription, Task, Window,
+    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Render, Styled,
+    Subscription, Task, Window,
 };
 use settings::Settings;
 use std::path::PathBuf;
-use terminal::{terminal_settings::TerminalSettings, Event as TerminalEvent, TerminalBuilder};
+use terminal::{
+    terminal_settings::TerminalSettings, Event as TerminalEvent, MaybeNavigationTarget,
+    TerminalBuilder,
+};
 use theme::ActiveTheme;
 use util::shell::Shell;
 
@@ -161,8 +165,53 @@ impl TerminalPane {
                 // Could play a sound or flash the window
                 tracing::debug!("Terminal bell");
             }
+            // Handle URL open events
+            TerminalEvent::Open(target) => {
+                self.handle_open_target(target, cx);
+            }
+            // Handle hover state changes
+            TerminalEvent::NewNavigationTarget(target) => {
+                self.handle_navigation_target(target, cx);
+            }
             _ => {}
         }
+    }
+
+    /// Handle opening a URL or path
+    #[allow(clippy::needless_pass_by_ref_mut)] // Called from event handler context
+    #[allow(clippy::unused_self)] // Method signature required by event handler pattern
+    fn handle_open_target(&mut self, target: &MaybeNavigationTarget, _cx: &mut Context<Self>) {
+        match target {
+            MaybeNavigationTarget::Url(url) => {
+                tracing::info!("Opening URL: {}", url);
+                if let Err(e) = open::that(url) {
+                    tracing::error!("Failed to open URL {}: {}", url, e);
+                }
+            }
+            MaybeNavigationTarget::PathLike(path_target) => {
+                // Future: implement path navigation
+                tracing::info!(
+                    "Path navigation requested: {:?}",
+                    path_target.maybe_path
+                );
+            }
+        }
+    }
+
+    /// Handle navigation target hover state changes
+    #[allow(clippy::needless_pass_by_ref_mut)] // Called from event handler context
+    #[allow(clippy::unused_self)] // Method signature required by event handler pattern
+    #[allow(clippy::ref_option)] // API signature from Zed terminal crate
+    fn handle_navigation_target(
+        &mut self,
+        target: &Option<MaybeNavigationTarget>,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(MaybeNavigationTarget::Url(url)) = target {
+            tracing::debug!("Hovering URL: {}", url);
+        }
+        // Ensure hover state clears immediately when target becomes None
+        cx.notify();
     }
 
     /// Get the active terminal tab
@@ -214,6 +263,51 @@ impl TerminalPane {
                 });
                 cx.notify();
             }
+        }
+    }
+
+    /// Handle mouse move events - forwards to Zed terminal for hyperlink detection
+    fn handle_mouse_move(
+        &mut self,
+        event: &MouseMoveEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(tab) = self.active_tab_mut() {
+            tab.terminal.update(cx, |terminal, cx| {
+                terminal.mouse_move(event, cx);
+            });
+            cx.notify();
+        }
+    }
+
+    /// Handle mouse down events - forwards to Zed terminal
+    fn handle_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(tab) = self.active_tab_mut() {
+            tab.terminal.update(cx, |terminal, cx| {
+                terminal.mouse_down(event, cx);
+            });
+            cx.notify();
+        }
+    }
+
+    /// Handle mouse up events - forwards to Zed terminal for URL opening
+    fn handle_mouse_up(
+        &mut self,
+        event: &MouseUpEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(tab) = self.active_tab_mut() {
+            tab.terminal.update(cx, |terminal, cx| {
+                terminal.mouse_up(event, cx);
+            });
+            cx.notify();
         }
     }
 
@@ -345,6 +439,9 @@ impl Render for TerminalPane {
             .flex_col()
             .size_full()
             .on_key_down(cx.listener(Self::handle_key_down))
+            .on_mouse_move(cx.listener(Self::handle_mouse_move))
+            .on_mouse_down(MouseButton::Left, cx.listener(Self::handle_mouse_down))
+            .on_mouse_up(MouseButton::Left, cx.listener(Self::handle_mouse_up))
             .child(self.render_terminal_content(cx))
             .child(self.render_tabs(cx))
     }

--- a/src/terminal/tab.rs
+++ b/src/terminal/tab.rs
@@ -2,7 +2,7 @@
 //!
 //! Each `TerminalTab` represents a single terminal session within the terminal pane.
 
-use gpui::{Context, Entity};
+use gpui::{Context, Entity, Subscription};
 use std::path::PathBuf;
 use terminal::Terminal;
 
@@ -14,20 +14,24 @@ pub struct TerminalTab {
     working_directory: Option<PathBuf>,
     /// Custom title (if set by user)
     custom_title: Option<String>,
+    /// Subscription to terminal events (automatically dropped when tab is dropped)
+    _subscription: Subscription,
 }
 
 impl TerminalTab {
-    /// Create a new terminal tab
+    /// Create a new terminal tab with its event subscription
     #[allow(clippy::missing_const_for_fn)] // Cannot be const due to generic lifetime bounds
     pub fn new<V: 'static>(
         terminal: Entity<Terminal>,
         working_directory: Option<PathBuf>,
+        subscription: Subscription,
         _cx: &mut Context<V>,
     ) -> Self {
         Self {
             terminal,
             working_directory,
             custom_title: None,
+            _subscription: subscription,
         }
     }
 


### PR DESCRIPTION
## Summary

Implements URL recognition and clicking functionality for TerminalG's terminal pane by leveraging Zed's existing hyperlink infrastructure.

**Sprint 2.3 Phases Completed:**
- Phase 1: URL regex configuration
- Phase 2: Mouse event wiring  
- Phase 3: Event handling for URL opening
- Phase 4: Visual feedback (intentionally deferred to future sprint)

## Key Changes

### Phase 1: URL Regex Configuration
- Added `DEFAULT_PATH_REGEXES` constant with file path patterns
- Pass regex patterns to `TerminalBuilder` for URL detection

### Phase 2: Mouse Event Wiring
- Added `handle_mouse_move()`, `handle_mouse_down()`, `handle_mouse_up()` methods
- Wire GPUI mouse events to Zed terminal handlers

### Phase 3: Event Handling
- Handle `TerminalEvent::Open` to launch URLs in browser via `open` crate
- Handle `TerminalEvent::NewNavigationTarget` for hover state tracking

## How It Works

1. User holds Ctrl (Windows/Linux) or Cmd (macOS) and hovers over URL
2. Zed's terminal detects URL via regex matching
3. User clicks while holding modifier key
4. `TerminalEvent::Open` is emitted
5. URL opens in default browser via `open::that()`

## Test plan

- [x] `cargo test` - 60/60 tests passing
- [x] `cargo clippy -- -D warnings` - clean
- [x] `cargo build --release` - success
- [ ] Manual test: Ctrl/Cmd+click on `https://example.com` opens browser
- [ ] Manual test: Works with http://, https://, git://, ssh:// URLs

## Design Document

See `docs/sprints/phase-2-sprint-3-design.md` for full architecture details.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)