### PR TITLE
feat: add resizable panes with draggable dividers

### DIFF
--- a/docs/design/resizable-panes.md
+++ b/docs/design/resizable-panes.md
@@ -1,0 +1,383 @@
+# Resizable Panes Design Document
+
+## Overview
+
+This document describes the architecture for adding draggable vertical dividers between panes in TerminalG, enabling users to resize the file browser, terminal, and document viewer panes.
+
+## Current State
+
+- **Layout**: `src/ui/workspace.rs` - `render_content()` uses equal `flex_1()` for all panes
+- **Config**: `src/ui/workspace_config.rs` - `pane_ratios: [f32; 3]` exists with defaults `[1.0, 2.0, 1.0]` but is **unused**
+- **Persistence**: Debounced save pattern already implemented (200ms delay)
+
+## Architecture Decision
+
+**Approach: Global Drag State with Mouse Event Handlers**
+
+Rationale:
+1. GPUI provides robust mouse event system (`on_mouse_down`, `on_mouse_move`, `on_mouse_up`)
+2. Global listeners enable drag continuation outside divider bounds
+3. State stored in `WorkspaceView` for simplicity
+4. Leverages existing persistence infrastructure
+
+## Component Design
+
+### 1. ResizeDragState
+
+```rust
+struct ResizeDragState {
+    divider_index: usize,      // 0 or 1 (between which panes)
+    start_x: Pixels,           // Initial mouse X position
+    start_ratios: [f32; 3],    // Initial pane ratios
+    total_width: Pixels,       // Available width for panes
+}
+```
+
+### 2. Divider Component
+
+- **Width**: 6px hitbox (discoverable but unobtrusive)
+- **Visual**: 1px visible border line
+- **Cursor**: `cursor_col_resize()` on hover
+- **States**: Normal, hover (highlighted), dragging (highlighted)
+- **Double-click**: Reset ratios to default
+
+### 3. WorkspaceView Modifications
+
+Add fields:
+```rust
+pub struct WorkspaceView {
+    // ... existing fields ...
+    resize_drag_state: Option<ResizeDragState>,
+}
+
+const MIN_PANE_WIDTH: Pixels = px(150.0);
+```
+
+## State Flow
+
+```
+Mouse Down on Divider
+    ↓
+Create ResizeDragState {
+    divider_index,
+    start_x: event.position.x,
+    start_ratios: current ratios,
+    total_width: container width
+}
+    ↓
+Store in WorkspaceView
+    ↓
+cx.notify() → Re-render
+
+Mouse Move (global listener)
+    ↓
+If drag_state.is_some():
+    Calculate delta_x
+    Calculate new ratios (with min-width constraints)
+    Update workspace_state.pane_ratios
+    cx.notify() → Re-render with new flex_basis values
+
+Mouse Up (global listener)
+    ↓
+Clear drag_state
+    ↓
+schedule_save() → Persist after 200ms debounce
+```
+
+## Implementation Plan
+
+### File: `src/ui/workspace.rs`
+
+#### New Methods
+
+```rust
+fn render_divider(&self, divider_index: usize, cx: &mut Context<Self>) -> impl IntoElement {
+    let is_dragging = self.resize_drag_state
+        .as_ref()
+        .map_or(false, |s| s.divider_index == divider_index);
+
+    div()
+        .w(px(6.0))
+        .h_full()
+        .cursor_col_resize()
+        .bg(if is_dragging {
+            cx.theme().colors().border_focused
+        } else {
+            cx.theme().colors().border
+        })
+        .on_mouse_down(MouseButton::Left, cx.listener(move |this, event, _, cx| {
+            this.start_resize_drag(divider_index, event.position.x, cx);
+        }))
+        .on_double_click(cx.listener(|this, _, _, cx| {
+            this.reset_pane_ratios(cx);
+        }))
+}
+
+fn start_resize_drag(&mut self, divider_index: usize, start_x: Pixels, cx: &mut Context<Self>) {
+    let ws = self.workspace_state.read(cx);
+    self.resize_drag_state = Some(ResizeDragState {
+        divider_index,
+        start_x,
+        start_ratios: ws.pane_ratios,
+        total_width: /* get from layout */,
+    });
+    cx.notify();
+}
+
+fn handle_resize_drag(&mut self, position_x: Pixels, cx: &mut Context<Self>) {
+    if let Some(ref drag_state) = self.resize_drag_state {
+        let delta = position_x - drag_state.start_x;
+        let new_ratios = self.calculate_new_ratios(drag_state, delta);
+
+        self.workspace_state.update(cx, |ws, _| {
+            ws.pane_ratios = new_ratios;
+        });
+        cx.notify();
+    }
+}
+
+fn end_resize_drag(&mut self, cx: &mut Context<Self>) {
+    if self.resize_drag_state.take().is_some() {
+        self.schedule_save(cx);
+        cx.notify();
+    }
+}
+
+fn calculate_new_ratios(&self, drag_state: &ResizeDragState, delta: Pixels) -> [f32; 3] {
+    // 1. Convert ratios to pixel widths
+    // 2. Apply delta to adjacent panes (divider_index and divider_index + 1)
+    // 3. Clamp to MIN_PANE_WIDTH
+    // 4. Normalize to maintain total
+    // 5. Return new ratios
+}
+
+fn reset_pane_ratios(&mut self, cx: &mut Context<Self>) {
+    self.workspace_state.update(cx, |ws, _| {
+        ws.pane_ratios = [1.0, 2.0, 1.0]; // Default
+    });
+    self.schedule_save(cx);
+    cx.notify();
+}
+```
+
+#### Modified render_content()
+
+```rust
+fn render_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    let ws = self.workspace_state.read(cx);
+    let ratios = ws.pane_ratios;
+    let visible = [ws.file_browser_visible, ws.terminal_visible, ws.document_viewer_visible];
+
+    // Calculate normalized ratios for visible panes only
+    let visible_ratios = self.normalized_visible_ratios(&ratios, &visible);
+
+    div()
+        .flex()
+        .flex_1()
+        .w_full()
+        // File browser
+        .when(visible[0], |d| {
+            d.child(
+                div()
+                    .flex_basis(relative(visible_ratios[0]))
+                    .child(self.render_pane(PaneType::FileBrowser, cx))
+            )
+        })
+        // Divider 0 (between file browser and terminal)
+        .when(visible[0] && visible[1], |d| {
+            d.child(self.render_divider(0, cx))
+        })
+        // Terminal
+        .when(visible[1], |d| {
+            d.child(
+                div()
+                    .flex_basis(relative(visible_ratios[1]))
+                    .child(self.render_pane(PaneType::Terminal, cx))
+            )
+        })
+        // Divider 1 (between terminal and doc viewer)
+        .when(visible[1] && visible[2], |d| {
+            d.child(self.render_divider(1, cx))
+        })
+        // Document viewer
+        .when(visible[2], |d| {
+            d.child(
+                div()
+                    .flex_basis(relative(visible_ratios[2]))
+                    .child(self.render_pane(PaneType::DocumentViewer, cx))
+            )
+        })
+}
+```
+
+#### Global Event Listeners
+
+Register in `new()` or use `on_mouse_move_out` / `on_mouse_up_out` on the container:
+
+```rust
+// Option 1: Global listeners in new()
+cx.on_mouse_event(move |this: &mut Self, event: &MouseMoveEvent, _, cx| {
+    this.handle_resize_drag(event.position.x, cx);
+});
+
+cx.on_mouse_event(move |this: &mut Self, _event: &MouseUpEvent, _, cx| {
+    this.end_resize_drag(cx);
+});
+
+// Option 2: On the content container div
+.on_mouse_move(cx.listener(|this, event, _, cx| {
+    this.handle_resize_drag(event.position.x, cx);
+}))
+.on_mouse_up(MouseButton::Left, cx.listener(|this, _, _, cx| {
+    this.end_resize_drag(cx);
+}))
+```
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Pane below min width | Clamp to MIN_PANE_WIDTH, redistribute excess |
+| Pane visibility toggle | Recalculate visible ratios, dynamic divider placement |
+| Window resize | Ratios are relative, auto-adapts |
+| Multiple dividers | Only one drag at a time (single drag_state) |
+| Drag outside window | Global listener continues tracking |
+
+## Build Sequence
+
+1. **Foundation** - Add structs, fields, method stubs
+2. **Divider Rendering** - Implement `render_divider()` with styling
+3. **Drag Handling** - Implement state management and global listeners
+4. **Layout Integration** - Modify `render_content()` for flex_basis
+5. **Constraints** - Min-width enforcement, double-click reset
+6. **Polish** - Visual feedback, hover states, testing
+
+## Files Changed
+
+- `src/ui/workspace.rs` - Main implementation
+- `src/ui/workspace_config.rs` - No changes needed (pane_ratios already exists)
+
+## Performance
+
+- Target: 60fps during drag
+- GPUI flex layout is optimized for frequent updates
+- Debounced persistence prevents disk thrashing
+
+---
+
+## ARCH-CODEX Review Findings
+
+Architecture review identified three issues to address as part of this implementation.
+
+### HIGH: Missing Minimum-Width Guard in TerminalElement
+
+**Location**: `src/terminal/element.rs:184-190`
+
+**Problem**: When computing `TerminalBounds`, there's no guard against extremely narrow widths. If a pane is resized very narrow (0-1 columns), `set_size` produces a degenerate grid that causes alacritty to misbehave with rendering glitches or crashes.
+
+**Reference**: Zed implements this guard in `terminal_element.rs:987-992`:
+```rust
+// https://github.com/zed-industries/zed/issues/2750
+// if the terminal is one column wide, rendering 🦀
+// causes alacritty to misbehave.
+if size.width < cell_width * 2.0 {
+    size.width = cell_width * 2.0;
+}
+```
+
+**Fix**: Add minimum width clamping before creating `TerminalBounds`:
+
+```rust
+// In element.rs prepaint(), before TerminalBounds::new:
+
+// Guard against narrow widths that cause alacritty to misbehave
+// See: https://github.com/zed-industries/zed/issues/2750
+let mut size = bounds.size;
+if size.width < cell_width * 2.0 {
+    size.width = cell_width * 2.0;
+}
+let clamped_bounds = Bounds { origin: bounds.origin, size };
+
+let dimensions = TerminalBounds::new(line_height, cell_width, clamped_bounds);
+```
+
+---
+
+### MEDIUM: Alt+Key Modifier Handling in Key Input
+
+**Location**: `src/terminal/pane.rs:325-343`
+
+**Problem**: The `key_char` fallback sends raw bytes even when Alt/Meta modifiers are present. Terminal applications expect Alt+key to send ESC followed by the key (e.g., Alt+b should send `\x1b` + `b` for backward-word in bash/readline).
+
+**Current Code**:
+```rust
+} else if let Some(key_char) = &event.keystroke.key_char {
+    // For plain text input, send the character directly to the terminal
+    terminal.input(key_char.as_bytes().to_vec());
+    cx.stop_propagation();
+}
+```
+
+**Fix**: Check for Alt/Meta modifiers and prepend ESC when present:
+
+```rust
+} else if let Some(key_char) = &event.keystroke.key_char {
+    let has_alt = event.keystroke.modifiers.alt;
+    let has_meta = option_as_meta && event.keystroke.modifiers.platform;
+
+    if has_alt || has_meta {
+        // Alt/Meta + key should send ESC followed by the key
+        let mut bytes = vec![0x1b]; // ESC
+        bytes.extend_from_slice(key_char.as_bytes());
+        terminal.input(bytes);
+    } else {
+        // Plain text input
+        terminal.input(key_char.as_bytes().to_vec());
+    }
+    cx.stop_propagation();
+}
+```
+
+**Impact**: Shell shortcuts like Alt+b (back word), Alt+f (forward word), Alt+d (delete word) will work correctly.
+
+---
+
+### LOW: Unused Code After TerminalElement Switch
+
+**Locations**:
+- `src/terminal/pane.rs:536-549` - `update_terminal_snapshot()`
+- `src/terminal/pane.rs` - `build_lines_from_content()` (top-level function)
+- `src/terminal/tab.rs:14,81-88` - `rendered_lines` field and accessors
+
+**Problem**: After switching to `TerminalElement`, which builds lines directly from `last_content()` in its prepaint phase, the old snapshot/caching code is unused but still runs on terminal events, causing unnecessary allocations.
+
+**Fix**: Remove dead code:
+
+1. Delete `update_terminal_snapshot()` method from `TerminalPane`
+2. Delete top-level `build_lines_from_content()` function (keep the one in `TerminalElement`)
+3. Remove `rendered_lines` field from `TerminalTab` struct
+4. Remove `set_rendered_lines()` and `rendered_lines()` methods from `TerminalTab`
+5. Remove any event handler calls to `update_terminal_snapshot()`
+
+---
+
+## Updated Build Sequence
+
+1. **Foundation** - Add structs, fields, method stubs
+2. **Divider Rendering** - Implement `render_divider()` with styling
+3. **Drag Handling** - Implement state management and global listeners
+4. **Layout Integration** - Modify `render_content()` for flex_basis
+5. **Constraints** - Min-width enforcement, double-click reset
+6. **Terminal Hardening** - Implement ARCH-CODEX fixes:
+   - Add minimum-width guard in `element.rs`
+   - Fix Alt+key handling in `pane.rs`
+   - Remove dead snapshot code
+7. **Polish** - Visual feedback, hover states, testing
+
+## Updated Files Changed
+
+- `src/ui/workspace.rs` - Main resizable panes implementation
+- `src/ui/workspace_config.rs` - No changes needed (pane_ratios already exists)
+- `src/terminal/element.rs` - Add minimum-width guard
+- `src/terminal/pane.rs` - Fix Alt+key handling, remove dead code
+- `src/terminal/tab.rs` - Remove unused `rendered_lines` field

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -181,8 +181,19 @@ impl Element for TerminalElement {
             .map(|advance| advance.width)
             .unwrap_or(px(8.4)); // Fallback
 
-        // Create terminal bounds from actual layout bounds
-        let dimensions = TerminalBounds::new(line_height, cell_width, bounds);
+        // Guard against narrow widths that cause alacritty to misbehave
+        // See: https://github.com/zed-industries/zed/issues/2750
+        let mut size = bounds.size;
+        if size.width < cell_width * 2.0 {
+            size.width = cell_width * 2.0;
+        }
+        let clamped_bounds = Bounds {
+            origin: bounds.origin,
+            size,
+        };
+
+        // Create terminal bounds from clamped layout bounds
+        let dimensions = TerminalBounds::new(line_height, cell_width, clamped_bounds);
 
         // Set terminal size and sync to populate cells
         self.terminal.update(cx, |terminal, cx| {

--- a/src/terminal/pane.rs
+++ b/src/terminal/pane.rs
@@ -13,7 +13,7 @@ use settings::Settings;
 use std::path::PathBuf;
 use terminal::{
     terminal_settings::TerminalSettings, Event as TerminalEvent, MaybeNavigationTarget, Terminal,
-    TerminalBuilder, TerminalContent,
+    TerminalBuilder,
 };
 use theme::ActiveTheme;
 use util::shell::Shell;
@@ -140,11 +140,8 @@ impl TerminalPane {
                                 pane.handle_terminal_event(&terminal, event, cx);
                             });
 
-                        let content = terminal.read(cx).last_content();
-                        let rendered_lines = build_lines_from_content(content);
-                        let mut tab =
+                        let tab =
                             TerminalTab::new(terminal.clone(), working_dir, subscription, cx);
-                        tab.set_rendered_lines(rendered_lines);
 
                         let tabs = pane
                             .tabs_by_workspace
@@ -175,7 +172,6 @@ impl TerminalPane {
     ) {
         match event {
             TerminalEvent::TitleChanged | TerminalEvent::BreadcrumbsChanged => {
-                self.update_terminal_snapshot(terminal, cx);
                 cx.emit(TerminalPaneEvent::TitleChanged);
                 cx.notify();
             }
@@ -183,7 +179,6 @@ impl TerminalPane {
                 self.close_terminal_by_id(terminal.entity_id(), cx);
             }
             TerminalEvent::Wakeup => {
-                self.update_terminal_snapshot(terminal, cx);
                 cx.notify();
             }
             TerminalEvent::Bell => {
@@ -337,8 +332,18 @@ impl TerminalPane {
                 if handled {
                     cx.stop_propagation();
                 } else if let Some(key_char) = &event.keystroke.key_char {
-                    // For plain text input, send the character directly to the terminal
-                    terminal.input(key_char.as_bytes().to_vec());
+                    let has_alt = event.keystroke.modifiers.alt;
+                    let has_meta = option_as_meta && event.keystroke.modifiers.platform;
+
+                    if has_alt || has_meta {
+                        // Alt/Meta + key should send ESC followed by the key
+                        let mut bytes = vec![0x1b]; // ESC
+                        bytes.extend_from_slice(key_char.as_bytes());
+                        terminal.input(bytes);
+                    } else {
+                        // Plain text input
+                        terminal.input(key_char.as_bytes().to_vec());
+                    }
                     cx.stop_propagation();
                 }
             });
@@ -534,22 +539,6 @@ impl Render for TerminalPane {
 }
 
 impl TerminalPane {
-    fn update_terminal_snapshot(&mut self, terminal: &Entity<Terminal>, cx: &Context<Self>) {
-        let content = terminal.read(cx).last_content();
-        let lines = build_lines_from_content(content);
-        let terminal_id = terminal.entity_id();
-
-        for tabs in self.tabs_by_workspace.values_mut() {
-            if let Some(tab) = tabs
-                .iter_mut()
-                .find(|tab| tab.matches_terminal(terminal_id))
-            {
-                tab.set_rendered_lines(lines);
-                break;
-            }
-        }
-    }
-
     fn close_terminal_by_id(&mut self, terminal_id: gpui::EntityId, cx: &mut Context<Self>) {
         let mut target: Option<(String, usize)> = None;
         for (workspace_id, tabs) in &self.tabs_by_workspace {
@@ -581,32 +570,6 @@ impl TerminalPane {
     }
 }
 
-fn build_lines_from_content(content: &TerminalContent) -> Vec<String> {
-    let mut lines: Vec<String> = Vec::new();
-    let mut current_line = String::new();
-    let mut current_row = 0i32;
-
-    for cell in &content.cells {
-        if cell.point.line.0 != current_row {
-            if !current_line.is_empty() || current_row < cell.point.line.0 {
-                lines.push(std::mem::take(&mut current_line));
-            }
-            // Fill empty lines
-            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-            while (lines.len() as i32) < cell.point.line.0 {
-                lines.push(String::new());
-            }
-            current_row = cell.point.line.0;
-        }
-        current_line.push(cell.c);
-    }
-    if !current_line.is_empty() {
-        lines.push(current_line);
-    }
-
-    lines
-}
-
 fn clamp_active_index(active_index: usize, len: usize) -> Option<usize> {
     if len == 0 {
         None
@@ -634,10 +597,7 @@ fn strip_line_col_suffix(path: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_lines_from_content, clamp_active_index, strip_line_col_suffix};
-    use terminal::alacritty_terminal::index::{Column, Line, Point as AlacPoint};
-    use terminal::alacritty_terminal::term::cell::Cell;
-    use terminal::{IndexedCell, TerminalContent};
+    use super::{clamp_active_index, strip_line_col_suffix};
 
     #[test]
     fn clamp_active_index_handles_empty() {
@@ -686,32 +646,5 @@ mod tests {
     #[test]
     fn strip_line_col_suffix_non_numeric_tail() {
         assert_eq!(strip_line_col_suffix("/tmp/foo:bar"), "/tmp/foo:bar");
-    }
-
-    #[test]
-    fn build_lines_from_content_inserts_empty_lines() {
-        let content = TerminalContent {
-            cells: vec![
-                IndexedCell {
-                    point: AlacPoint::new(Line(0), Column(0)),
-                    cell: Cell {
-                        c: 'a',
-                        ..Default::default()
-                    },
-                },
-                IndexedCell {
-                    point: AlacPoint::new(Line(2), Column(0)),
-                    cell: Cell {
-                        c: 'b',
-                        ..Default::default()
-                    },
-                },
-            ],
-            ..Default::default()
-        };
-
-        let lines = build_lines_from_content(&content);
-
-        assert_eq!(lines, vec!["a".to_string(), String::new(), "b".to_string()]);
     }
 }

--- a/src/terminal/pane.rs
+++ b/src/terminal/pane.rs
@@ -140,8 +140,7 @@ impl TerminalPane {
                                 pane.handle_terminal_event(&terminal, event, cx);
                             });
 
-                        let tab =
-                            TerminalTab::new(terminal.clone(), working_dir, subscription, cx);
+                        let tab = TerminalTab::new(terminal.clone(), working_dir, subscription, cx);
 
                         let tabs = pane
                             .tabs_by_workspace

--- a/src/terminal/tab.rs
+++ b/src/terminal/tab.rs
@@ -10,8 +10,6 @@ use terminal::Terminal;
 pub struct TerminalTab {
     /// The underlying Zed terminal
     pub terminal: Entity<Terminal>,
-    /// Cached terminal output lines for render
-    rendered_lines: Option<Vec<String>>,
     /// Working directory for this terminal
     working_directory: Option<PathBuf>,
     /// Custom title (if set by user)
@@ -31,7 +29,6 @@ impl TerminalTab {
     ) -> Self {
         Self {
             terminal,
-            rendered_lines: None,
             working_directory,
             custom_title: None,
             _subscription: subscription,
@@ -75,16 +72,5 @@ impl TerminalTab {
     /// Check if this tab matches a terminal entity ID
     pub fn matches_terminal(&self, terminal_id: EntityId) -> bool {
         self.terminal.entity_id() == terminal_id
-    }
-
-    /// Update cached rendered lines for this tab.
-    pub fn set_rendered_lines(&mut self, lines: Vec<String>) {
-        self.rendered_lines = Some(lines);
-    }
-
-    /// Get cached rendered lines for this tab.
-    #[allow(dead_code)] // Available for debugging/future use
-    pub fn rendered_lines(&self) -> Option<&[String]> {
-        self.rendered_lines.as_deref()
     }
 }

--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -5,16 +5,19 @@
 use crate::terminal::{TerminalPane, TerminalPaneEvent};
 use crate::ui::workspace_config::WorkspaceConfigStore;
 use gpui::{
-    div, prelude::*, px, relative, ClickEvent, ElementId, Entity, IntoElement, MouseButton,
-    MouseDownEvent, MouseMoveEvent, Pixels, Render, Styled, Subscription, Task, Window,
+    div, prelude::*, px, relative, App, Bounds, ClickEvent, Element, ElementId, Entity,
+    GlobalElementId, IntoElement, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, Pixels,
+    Render, Size, Style, Styled, Subscription, Task, WeakEntity, Window,
 };
 use std::time::Duration;
 use theme::ActiveTheme;
 
 /// Minimum width for a pane to prevent narrow/unusable layouts
 const MIN_PANE_WIDTH: Pixels = px(150.0);
+const DIVIDER_WIDTH: Pixels = px(6.0);
 
 /// State tracking for drag-to-resize operations on pane dividers
+#[derive(Clone, Copy)]
 struct ResizeDragState {
     /// Index of the divider being dragged (0 = left divider, 1 = right divider)
     divider_index: usize,
@@ -24,6 +27,89 @@ struct ResizeDragState {
     start_ratios: [f32; 3],
     /// Total available width for all panes at drag start
     total_width: Pixels,
+}
+
+/// Element that captures the bounds of its layout and reports width to the workspace view.
+struct ContentBoundsReporter {
+    target: WeakEntity<WorkspaceView>,
+    id: ElementId,
+}
+
+impl ContentBoundsReporter {
+    fn new(target: WeakEntity<WorkspaceView>, id: impl Into<ElementId>) -> Self {
+        Self {
+            target,
+            id: id.into(),
+        }
+    }
+}
+
+impl IntoElement for ContentBoundsReporter {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for ContentBoundsReporter {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&gpui::InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let style = Style {
+            size: Size {
+                width: gpui::relative(1.).into(),
+                height: gpui::relative(1.).into(),
+            },
+            ..Default::default()
+        };
+        let layout_id = window.request_layout(style, None, cx);
+        (layout_id, ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&gpui::InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        if let Some(target) = self.target.upgrade() {
+            let width = bounds.size.width;
+            target.update(cx, |view, _cx| {
+                view.content_width = Some(width);
+            });
+        }
+    }
+
+    fn paint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&gpui::InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _layout: &mut Self::PrepaintState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) {
+    }
 }
 
 /// Main workspace view with tab bar and three-pane layout
@@ -42,6 +128,9 @@ pub struct WorkspaceView {
 
     /// Active resize drag state (Some when user is dragging a divider)
     resize_drag_state: Option<ResizeDragState>,
+
+    /// Last known content width for pane layout calculations
+    content_width: Option<Pixels>,
 }
 
 /// Pane type identifier
@@ -110,6 +199,7 @@ impl WorkspaceView {
             _terminal_subscription: terminal_subscription,
             save_task: None,
             resize_drag_state: None,
+            content_width: None,
         }
     }
 
@@ -179,7 +269,12 @@ impl WorkspaceView {
 
     /// Render vertical divider between panes
     #[allow(clippy::needless_pass_by_ref_mut)] // cx.listener requires &mut Context
-    fn render_divider(&self, divider_index: usize, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_divider(
+        &self,
+        divider_index: usize,
+        total_width: Pixels,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
         let is_dragging = self
             .resize_drag_state
             .as_ref()
@@ -203,8 +298,7 @@ impl WorkspaceView {
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(move |this, event: &MouseDownEvent, _window, cx| {
-                    // Use a placeholder width - will be recalculated during drag
-                    this.start_resize_drag(divider_index, event.position.x, px(1000.0), cx);
+                    this.start_resize_drag(divider_index, event.position.x, total_width, cx);
                 }),
             )
             .on_click(cx.listener(move |this, event: &ClickEvent, _window, cx| {
@@ -226,11 +320,24 @@ impl WorkspaceView {
         cx: &mut Context<Self>,
     ) {
         let ws = self.config_store.active_workspace();
+        let visible = [
+            ws.file_browser_visible,
+            ws.terminal_visible,
+            ws.document_viewer_visible,
+        ];
+        let available_width = if total_width > px(0.0) {
+            total_width
+        } else {
+            self.available_panes_width(visible)
+        };
+        if available_width <= px(0.0) {
+            return;
+        }
         self.resize_drag_state = Some(ResizeDragState {
             divider_index,
             start_x,
             start_ratios: ws.pane_ratios,
-            total_width,
+            total_width: available_width,
         });
         cx.notify();
     }
@@ -238,8 +345,20 @@ impl WorkspaceView {
     /// Handle mouse movement during drag-to-resize
     fn handle_resize_drag(&mut self, position_x: Pixels, cx: &mut Context<Self>) {
         if let Some(ref drag_state) = self.resize_drag_state {
+            let ws = self.config_store.active_workspace();
+            let visible = [
+                ws.file_browser_visible,
+                ws.terminal_visible,
+                ws.document_viewer_visible,
+            ];
+            let available_width = self.available_panes_width(visible);
+            let total_width = if available_width > px(0.0) {
+                available_width
+            } else {
+                drag_state.total_width
+            };
             let delta = position_x - drag_state.start_x;
-            let new_ratios = self.calculate_new_ratios(drag_state, delta);
+            let new_ratios = calculate_new_ratios(drag_state, delta, visible, total_width);
 
             let ws = self.config_store.active_workspace_mut();
             ws.pane_ratios = new_ratios;
@@ -257,49 +376,6 @@ impl WorkspaceView {
 
     /// Calculate new pane ratios based on drag delta, enforcing minimum widths
     #[allow(clippy::unused_self)] // Method for consistency with other instance methods
-    fn calculate_new_ratios(&self, drag_state: &ResizeDragState, delta: Pixels) -> [f32; 3] {
-        let total_width = drag_state.total_width;
-        let ratios = drag_state.start_ratios;
-
-        // Calculate total ratio sum for normalization
-        let total_ratio: f32 = ratios.iter().sum();
-
-        // Convert ratios to pixel widths
-        let mut widths = [
-            (ratios[0] / total_ratio) * total_width,
-            (ratios[1] / total_ratio) * total_width,
-            (ratios[2] / total_ratio) * total_width,
-        ];
-
-        // Apply delta to the two panes adjacent to the divider
-        let left_idx = drag_state.divider_index;
-        let right_idx = drag_state.divider_index + 1;
-
-        widths[left_idx] += delta;
-        widths[right_idx] -= delta;
-
-        // Enforce minimum widths
-        if widths[left_idx] < MIN_PANE_WIDTH {
-            let deficit = MIN_PANE_WIDTH - widths[left_idx];
-            widths[left_idx] = MIN_PANE_WIDTH;
-            widths[right_idx] -= deficit;
-        }
-
-        if widths[right_idx] < MIN_PANE_WIDTH {
-            let deficit = MIN_PANE_WIDTH - widths[right_idx];
-            widths[right_idx] = MIN_PANE_WIDTH;
-            widths[left_idx] -= deficit;
-        }
-
-        // Convert back to ratios
-        let total_width_actual = widths[0] + widths[1] + widths[2];
-        [
-            widths[0] / total_width_actual,
-            widths[1] / total_width_actual,
-            widths[2] / total_width_actual,
-        ]
-    }
-
     /// Reset pane ratios to default [1.0, 2.0, 1.0]
     fn reset_pane_ratios(&mut self, cx: &mut Context<Self>) {
         let ws = self.config_store.active_workspace_mut();
@@ -323,10 +399,42 @@ impl WorkspaceView {
         }
 
         [
-            if visible[0] { ratios[0] / visible_sum } else { 0.0 },
-            if visible[1] { ratios[1] / visible_sum } else { 0.0 },
-            if visible[2] { ratios[2] / visible_sum } else { 0.0 },
+            if visible[0] {
+                ratios[0] / visible_sum
+            } else {
+                0.0
+            },
+            if visible[1] {
+                ratios[1] / visible_sum
+            } else {
+                0.0
+            },
+            if visible[2] {
+                ratios[2] / visible_sum
+            } else {
+                0.0
+            },
         ]
+    }
+
+    fn available_panes_width(&self, visible: [bool; 3]) -> Pixels {
+        let Some(content_width) = self.content_width else {
+            return px(0.0);
+        };
+        let divider_count =
+            usize::from(visible[0] && visible[1]) + usize::from(visible[1] && visible[2]);
+        let divider_factor = match divider_count {
+            0 => 0.0,
+            1 => 1.0,
+            _ => 2.0,
+        };
+        let divider_width = DIVIDER_WIDTH * divider_factor;
+        let available = content_width - divider_width;
+        if available > px(0.0) {
+            available
+        } else {
+            px(0.0)
+        }
     }
 
     /// Render workspace tab bar
@@ -391,6 +499,7 @@ impl WorkspaceView {
             ws.terminal_visible,
             ws.document_viewer_visible,
         ];
+        let available_width = self.available_panes_width(visible);
 
         // Calculate normalized ratios for visible panes only
         let visible_ratios = self.normalized_visible_ratios(&ratios, visible);
@@ -399,11 +508,27 @@ impl WorkspaceView {
             .flex()
             .flex_1()
             .w_full()
+            .relative()
+            .child(
+                div()
+                    .absolute()
+                    .size_full()
+                    .child(ContentBoundsReporter::new(
+                        cx.weak_entity(),
+                        "workspace-content-bounds",
+                    )),
+            )
             // Global mouse event handlers for drag continuation
             .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, cx| {
                 this.handle_resize_drag(event.position.x, cx);
             }))
             .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, _event, _window, cx| {
+                    this.end_resize_drag(cx);
+                }),
+            )
+            .on_mouse_up_out(
                 MouseButton::Left,
                 cx.listener(|this, _event, _window, cx| {
                     this.end_resize_drag(cx);
@@ -419,7 +544,7 @@ impl WorkspaceView {
             })
             // Divider 0 (between file browser and terminal)
             .when(visible[0] && visible[1], |d| {
-                d.child(self.render_divider(0, cx))
+                d.child(self.render_divider(0, available_width, cx))
             })
             // Terminal
             .when(visible[1], |d| {
@@ -431,7 +556,7 @@ impl WorkspaceView {
             })
             // Divider 1 (between terminal and doc viewer)
             .when(visible[1] && visible[2], |d| {
-                d.child(self.render_divider(1, cx))
+                d.child(self.render_divider(1, available_width, cx))
             })
             // Document viewer
             .when(visible[2], |d| {
@@ -554,5 +679,166 @@ impl Render for WorkspaceView {
             .bg(theme.colors().background)
             .child(self.render_tab_bar(cx))
             .child(self.render_content(cx))
+    }
+}
+
+fn calculate_new_ratios(
+    drag_state: &ResizeDragState,
+    delta: Pixels,
+    visible: [bool; 3],
+    total_width: Pixels,
+) -> [f32; 3] {
+    let mut ratios = drag_state.start_ratios;
+    let visible_count = visible.iter().filter(|v| **v).count();
+    if visible_count < 2 || total_width <= px(0.0) {
+        return ratios;
+    }
+
+    let visible_factor = match visible_count {
+        0 => 0.0,
+        1 => 1.0,
+        2 => 2.0,
+        _ => 3.0,
+    };
+    let min_total_width = MIN_PANE_WIDTH * visible_factor;
+    if total_width < min_total_width {
+        return ratios;
+    }
+
+    let left_idx = drag_state.divider_index;
+    if left_idx >= 2 {
+        return ratios;
+    }
+    let right_idx = left_idx + 1;
+    if !visible[left_idx] || !visible[right_idx] {
+        return ratios;
+    }
+
+    let hidden_ratio_sum: f32 = ratios
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !visible[*i])
+        .map(|(_, ratio)| *ratio)
+        .sum();
+    let visible_ratio_total = 1.0 - hidden_ratio_sum;
+    if visible_ratio_total <= 0.0 {
+        return ratios;
+    }
+
+    let mut widths = [px(0.0); 3];
+    for (idx, width) in widths.iter_mut().enumerate() {
+        if visible[idx] {
+            *width = (ratios[idx] / visible_ratio_total) * total_width;
+        }
+    }
+
+    widths[left_idx] += delta;
+    widths[right_idx] -= delta;
+
+    let mut left = widths[left_idx];
+    let mut right = widths[right_idx];
+
+    if left < MIN_PANE_WIDTH {
+        let deficit = MIN_PANE_WIDTH - left;
+        left = MIN_PANE_WIDTH;
+        right -= deficit;
+    }
+
+    if right < MIN_PANE_WIDTH {
+        let deficit = MIN_PANE_WIDTH - right;
+        right = MIN_PANE_WIDTH;
+        left -= deficit;
+    }
+
+    if left < MIN_PANE_WIDTH || right < MIN_PANE_WIDTH {
+        return ratios;
+    }
+
+    widths[left_idx] = left;
+    widths[right_idx] = right;
+
+    for (idx, ratio) in ratios.iter_mut().enumerate() {
+        if visible[idx] {
+            *ratio = (widths[idx] / total_width) * visible_ratio_total;
+        }
+    }
+
+    ratios
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{calculate_new_ratios, ResizeDragState};
+    use gpui::px;
+
+    fn assert_approx(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() < 1e-3,
+            "actual={actual} expected={expected}"
+        );
+    }
+
+    #[test]
+    fn calculate_new_ratios_keeps_hidden_pane_ratios() {
+        let drag_state = ResizeDragState {
+            divider_index: 1,
+            start_x: px(0.0),
+            start_ratios: [0.2, 0.4, 0.4],
+            total_width: px(400.0),
+        };
+        let visible = [false, true, true];
+        let result = calculate_new_ratios(&drag_state, px(40.0), visible, px(400.0));
+
+        assert_approx(result[0], 0.2);
+        assert_approx(result[1], 0.48);
+        assert_approx(result[2], 0.32);
+    }
+
+    #[test]
+    fn calculate_new_ratios_returns_original_when_too_narrow() {
+        let drag_state = ResizeDragState {
+            divider_index: 0,
+            start_x: px(0.0),
+            start_ratios: [0.33, 0.33, 0.34],
+            total_width: px(200.0),
+        };
+        let visible = [true, true, true];
+        let result = calculate_new_ratios(&drag_state, px(20.0), visible, px(200.0));
+
+        assert_approx(result[0], 0.33);
+        assert_approx(result[1], 0.33);
+        assert_approx(result[2], 0.34);
+    }
+
+    #[test]
+    fn calculate_new_ratios_clamps_min_widths() {
+        let drag_state = ResizeDragState {
+            divider_index: 0,
+            start_x: px(0.0),
+            start_ratios: [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0],
+            total_width: px(600.0),
+        };
+        let visible = [true, true, true];
+        let result = calculate_new_ratios(&drag_state, px(80.0), visible, px(600.0));
+
+        assert_approx(result[0], 250.0 / 600.0);
+        assert_approx(result[1], 150.0 / 600.0);
+        assert_approx(result[2], 200.0 / 600.0);
+    }
+
+    #[test]
+    fn calculate_new_ratios_rejects_invalid_clamp() {
+        let drag_state = ResizeDragState {
+            divider_index: 0,
+            start_x: px(0.0),
+            start_ratios: [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0],
+            total_width: px(300.0),
+        };
+        let visible = [true, true, true];
+        let result = calculate_new_ratios(&drag_state, px(100.0), visible, px(300.0));
+
+        assert_approx(result[0], 1.0 / 3.0);
+        assert_approx(result[1], 1.0 / 3.0);
+        assert_approx(result[2], 1.0 / 3.0);
     }
 }

--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -5,10 +5,26 @@
 use crate::terminal::{TerminalPane, TerminalPaneEvent};
 use crate::ui::workspace_config::WorkspaceConfigStore;
 use gpui::{
-    div, prelude::*, px, ElementId, Entity, IntoElement, Render, Styled, Subscription, Task, Window,
+    div, prelude::*, px, relative, ClickEvent, ElementId, Entity, IntoElement, MouseButton,
+    MouseDownEvent, MouseMoveEvent, Pixels, Render, Styled, Subscription, Task, Window,
 };
 use std::time::Duration;
 use theme::ActiveTheme;
+
+/// Minimum width for a pane to prevent narrow/unusable layouts
+const MIN_PANE_WIDTH: Pixels = px(150.0);
+
+/// State tracking for drag-to-resize operations on pane dividers
+struct ResizeDragState {
+    /// Index of the divider being dragged (0 = left divider, 1 = right divider)
+    divider_index: usize,
+    /// Initial X position of the mouse when drag started
+    start_x: Pixels,
+    /// Pane ratios at the start of the drag operation
+    start_ratios: [f32; 3],
+    /// Total available width for all panes at drag start
+    total_width: Pixels,
+}
 
 /// Main workspace view with tab bar and three-pane layout
 pub struct WorkspaceView {
@@ -23,6 +39,9 @@ pub struct WorkspaceView {
 
     /// Debounce timer for auto-save (task handle)
     save_task: Option<Task<()>>,
+
+    /// Active resize drag state (Some when user is dragging a divider)
+    resize_drag_state: Option<ResizeDragState>,
 }
 
 /// Pane type identifier
@@ -90,6 +109,7 @@ impl WorkspaceView {
             terminal_pane,
             _terminal_subscription: terminal_subscription,
             save_task: None,
+            resize_drag_state: None,
         }
     }
 
@@ -157,6 +177,158 @@ impl WorkspaceView {
         }));
     }
 
+    /// Render vertical divider between panes
+    #[allow(clippy::needless_pass_by_ref_mut)] // cx.listener requires &mut Context
+    fn render_divider(&self, divider_index: usize, cx: &mut Context<Self>) -> impl IntoElement {
+        let is_dragging = self
+            .resize_drag_state
+            .as_ref()
+            .is_some_and(|s| s.divider_index == divider_index);
+
+        let theme = cx.theme();
+
+        div()
+            .id(ElementId::NamedInteger(
+                "pane-divider".into(),
+                divider_index as u64,
+            ))
+            .w(px(6.0))
+            .h_full()
+            .cursor_col_resize()
+            .bg(if is_dragging {
+                theme.colors().border_focused
+            } else {
+                theme.colors().border
+            })
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, event: &MouseDownEvent, _window, cx| {
+                    // Use a placeholder width - will be recalculated during drag
+                    this.start_resize_drag(divider_index, event.position.x, px(1000.0), cx);
+                }),
+            )
+            .on_click(cx.listener(move |this, event: &ClickEvent, _window, cx| {
+                // Double-click to reset ratios
+                if let ClickEvent::Mouse(mouse_event) = event {
+                    if mouse_event.up.click_count == 2 {
+                        this.reset_pane_ratios(cx);
+                    }
+                }
+            }))
+    }
+
+    /// Start drag-to-resize operation on a divider
+    fn start_resize_drag(
+        &mut self,
+        divider_index: usize,
+        start_x: Pixels,
+        total_width: Pixels,
+        cx: &mut Context<Self>,
+    ) {
+        let ws = self.config_store.active_workspace();
+        self.resize_drag_state = Some(ResizeDragState {
+            divider_index,
+            start_x,
+            start_ratios: ws.pane_ratios,
+            total_width,
+        });
+        cx.notify();
+    }
+
+    /// Handle mouse movement during drag-to-resize
+    fn handle_resize_drag(&mut self, position_x: Pixels, cx: &mut Context<Self>) {
+        if let Some(ref drag_state) = self.resize_drag_state {
+            let delta = position_x - drag_state.start_x;
+            let new_ratios = self.calculate_new_ratios(drag_state, delta);
+
+            let ws = self.config_store.active_workspace_mut();
+            ws.pane_ratios = new_ratios;
+            cx.notify();
+        }
+    }
+
+    /// End drag-to-resize operation and persist changes
+    fn end_resize_drag(&mut self, cx: &mut Context<Self>) {
+        if self.resize_drag_state.take().is_some() {
+            self.schedule_save(cx);
+            cx.notify();
+        }
+    }
+
+    /// Calculate new pane ratios based on drag delta, enforcing minimum widths
+    #[allow(clippy::unused_self)] // Method for consistency with other instance methods
+    fn calculate_new_ratios(&self, drag_state: &ResizeDragState, delta: Pixels) -> [f32; 3] {
+        let total_width = drag_state.total_width;
+        let ratios = drag_state.start_ratios;
+
+        // Calculate total ratio sum for normalization
+        let total_ratio: f32 = ratios.iter().sum();
+
+        // Convert ratios to pixel widths
+        let mut widths = [
+            (ratios[0] / total_ratio) * total_width,
+            (ratios[1] / total_ratio) * total_width,
+            (ratios[2] / total_ratio) * total_width,
+        ];
+
+        // Apply delta to the two panes adjacent to the divider
+        let left_idx = drag_state.divider_index;
+        let right_idx = drag_state.divider_index + 1;
+
+        widths[left_idx] += delta;
+        widths[right_idx] -= delta;
+
+        // Enforce minimum widths
+        if widths[left_idx] < MIN_PANE_WIDTH {
+            let deficit = MIN_PANE_WIDTH - widths[left_idx];
+            widths[left_idx] = MIN_PANE_WIDTH;
+            widths[right_idx] -= deficit;
+        }
+
+        if widths[right_idx] < MIN_PANE_WIDTH {
+            let deficit = MIN_PANE_WIDTH - widths[right_idx];
+            widths[right_idx] = MIN_PANE_WIDTH;
+            widths[left_idx] -= deficit;
+        }
+
+        // Convert back to ratios
+        let total_width_actual = widths[0] + widths[1] + widths[2];
+        [
+            widths[0] / total_width_actual,
+            widths[1] / total_width_actual,
+            widths[2] / total_width_actual,
+        ]
+    }
+
+    /// Reset pane ratios to default [1.0, 2.0, 1.0]
+    fn reset_pane_ratios(&mut self, cx: &mut Context<Self>) {
+        let ws = self.config_store.active_workspace_mut();
+        ws.pane_ratios = [1.0, 2.0, 1.0];
+        self.schedule_save(cx);
+        cx.notify();
+    }
+
+    /// Calculate normalized ratios for only visible panes
+    #[allow(clippy::unused_self)] // Method for consistency with other instance methods
+    fn normalized_visible_ratios(&self, ratios: &[f32; 3], visible: [bool; 3]) -> [f32; 3] {
+        let visible_sum: f32 = ratios
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| visible[*i])
+            .map(|(_, r)| r)
+            .sum();
+
+        if visible_sum == 0.0 {
+            return [0.0, 0.0, 0.0];
+        }
+
+        [
+            if visible[0] { ratios[0] / visible_sum } else { 0.0 },
+            if visible[1] { ratios[1] / visible_sum } else { 0.0 },
+            if visible[2] { ratios[2] / visible_sum } else { 0.0 },
+        ]
+    }
+
     /// Render workspace tab bar
     fn render_tab_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
@@ -210,22 +382,64 @@ impl WorkspaceView {
             }))
     }
 
-    /// Render three-pane content area
+    /// Render three-pane content area with dynamic flex basis and dividers
     fn render_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let ws = self.config_store.active_workspace();
+        let ratios = ws.pane_ratios;
+        let visible = [
+            ws.file_browser_visible,
+            ws.terminal_visible,
+            ws.document_viewer_visible,
+        ];
+
+        // Calculate normalized ratios for visible panes only
+        let visible_ratios = self.normalized_visible_ratios(&ratios, visible);
 
         div()
             .flex()
             .flex_1()
             .w_full()
-            .when(ws.file_browser_visible, |d| {
-                d.child(self.render_pane(PaneType::FileBrowser, cx))
+            // Global mouse event handlers for drag continuation
+            .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, cx| {
+                this.handle_resize_drag(event.position.x, cx);
+            }))
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, _event, _window, cx| {
+                    this.end_resize_drag(cx);
+                }),
+            )
+            // File browser
+            .when(visible[0], |d| {
+                d.child(
+                    div()
+                        .flex_basis(relative(visible_ratios[0]))
+                        .child(self.render_pane(PaneType::FileBrowser, cx)),
+                )
             })
-            .when(ws.terminal_visible, |d| {
-                d.child(self.render_pane(PaneType::Terminal, cx))
+            // Divider 0 (between file browser and terminal)
+            .when(visible[0] && visible[1], |d| {
+                d.child(self.render_divider(0, cx))
             })
-            .when(ws.document_viewer_visible, |d| {
-                d.child(self.render_pane(PaneType::DocumentViewer, cx))
+            // Terminal
+            .when(visible[1], |d| {
+                d.child(
+                    div()
+                        .flex_basis(relative(visible_ratios[1]))
+                        .child(self.render_pane(PaneType::Terminal, cx)),
+                )
+            })
+            // Divider 1 (between terminal and doc viewer)
+            .when(visible[1] && visible[2], |d| {
+                d.child(self.render_divider(1, cx))
+            })
+            // Document viewer
+            .when(visible[2], |d| {
+                d.child(
+                    div()
+                        .flex_basis(relative(visible_ratios[2]))
+                        .child(self.render_pane(PaneType::DocumentViewer, cx)),
+                )
             })
     }
 


### PR DESCRIPTION
## Summary

- Add draggable vertical dividers between panes for user-controlled sizing
- Implement terminal hardening fixes from ARCH-CODEX architecture review
- Remove dead code from previous terminal element refactor

## Changes

### Resizable Panes
- `ResizeDragState` struct tracks drag operations (divider index, start position, ratios)
- `render_divider()` creates 6px hitbox with col-resize cursor and visual feedback
- `flex_basis(relative(ratio))` layout replaces equal `flex_1()` sizing
- Double-click divider resets to default ratios (1:2:1)
- `MIN_PANE_WIDTH` (150px) enforced during resize
- Ratios persist via existing debounced save mechanism

### Terminal Hardening (ARCH-CODEX)
- **HIGH**: Add minimum-width guard (2 columns) to prevent alacritty rendering crashes
- **MEDIUM**: Fix Alt+key handling to prepend ESC for shell shortcuts (Alt+b, Alt+f, etc.)
- **LOW**: Remove unused `update_terminal_snapshot`, `build_lines_from_content`, and `rendered_lines`

## Files Changed
- `src/ui/workspace.rs` - Main resizable panes implementation
- `src/terminal/element.rs` - Minimum-width guard
- `src/terminal/pane.rs` - Alt+key fix, dead code removal
- `src/terminal/tab.rs` - Remove unused field
- `docs/design/resizable-panes.md` - Design document

## Test plan
- [ ] Build passes: `cargo check`
- [ ] Clippy clean: `cargo clippy --all-targets`
- [ ] Tests pass: `cargo test` (68 tests)
- [ ] Manual: Drag dividers to resize panes
- [ ] Manual: Double-click divider to reset ratios
- [ ] Manual: Test Alt+b/Alt+f in terminal for word navigation
- [ ] Manual: Resize window very narrow to test minimum-width guard

🤖 Generated with [Claude Code](https://claude.ai/code)