### PR TITLE
fix: terminal pane layout - ensure proper height propagation

### DIFF
--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -574,7 +574,7 @@ impl WorkspaceView {
         div()
             .flex()
             .flex_1()
-            .w_full()
+            .size_full()
             .relative()
             .child(
                 div()
@@ -606,6 +606,7 @@ impl WorkspaceView {
                 d.child(
                     div()
                         .flex_basis(relative(visible_ratios[0]))
+                        .h_full()
                         .child(self.render_pane(PaneType::FileBrowser, cx)),
                 )
             })
@@ -618,6 +619,7 @@ impl WorkspaceView {
                 d.child(
                     div()
                         .flex_basis(relative(visible_ratios[1]))
+                        .h_full()
                         .child(self.render_pane(PaneType::Terminal, cx)),
                 )
             })
@@ -630,6 +632,7 @@ impl WorkspaceView {
                 d.child(
                     div()
                         .flex_basis(relative(visible_ratios[2]))
+                        .h_full()
                         .child(self.render_pane(PaneType::DocumentViewer, cx)),
                 )
             })
@@ -655,13 +658,12 @@ impl WorkspaceView {
         // Terminal pane renders the actual TerminalPane component
         if pane_type == PaneType::Terminal {
             return div()
-                .flex_1()
+                .size_full()
                 .flex()
                 .flex_col()
                 .m_2()
                 .bg(theme.colors().panel_background)
                 .rounded_md()
-                .overflow_hidden()
                 .child(
                     div()
                         .flex()
@@ -680,7 +682,14 @@ impl WorkspaceView {
                         )
                         .child(self.render_hide_button(pane_type, cx)),
                 )
-                .child(self.terminal_pane.clone());
+                .child(
+                    div()
+                        .flex_1()
+                        .size_full()
+                        .min_h_0()
+                        .overflow_hidden()
+                        .child(self.terminal_pane.clone()),
+                );
         }
 
         // Document viewer renders placeholder


### PR DESCRIPTION
## Summary
- Fixed terminal pane rendering with 0 height due to missing height constraints in flex layout chain
- Terminal now displays shell prompt correctly

## Root Cause
The terminal pane container used `flex_1()` with `overflow_hidden()` which caused the height to collapse to 0. The flex layout wasn't propagating height properly through the container hierarchy.

## Changes
- `render_content()`: Changed `w_full()` to `size_full()` to provide explicit height
- All pane wrappers: Added `h_full()` to stretch vertically in the flex row container
- Terminal pane container: Changed from `flex_1()` to `size_full()` and removed `overflow_hidden()` from outer container
- Added proper wrapper around `terminal_pane` with `flex_1()`/`min_h_0()`/`overflow_hidden()` to correctly contain terminal content

## Test plan
- [x] Build passes
- [x] Clippy passes
- [x] Terminal displays shell prompt on launch
- [x] Terminal dimensions are correct (88x34 with 680.5px height)

🤖 Generated with [Claude Code](https://claude.com/claude-code)